### PR TITLE
perf(notification): optimize Redis & transaction architecture with REQUIRES_NEW, async afterCommit, and pipeline batching

### DIFF
--- a/config-repo/notification-service.yml
+++ b/config-repo/notification-service.yml
@@ -35,6 +35,10 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 # 임시키
 session:

--- a/config-repo/notification-service.yml
+++ b/config-repo/notification-service.yml
@@ -26,6 +26,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
+      # JPA batch.
+      jdbc:
+        batch_size: 1000           # 한 번에 전송할 레코드 수
+      order_inserts: true          # 같은 테이블 insert끼리 모아서 정렬
+      order_updates: true          # 같은 테이블 update끼리 모아서 정렬
+
   h2:
     console:
       enabled: false

--- a/config-repo/notification-service.yml
+++ b/config-repo/notification-service.yml
@@ -14,8 +14,8 @@ spring:
       auto-offset-reset: earliest
     listener:
       missing-topics-fatal: false
-  datasource:
-    url: jdbc:mysql://mysql_notification:3306/notification_db?useSSL=false&allowPublicKeyRetrieval=true
+  datasource: # batch 처리
+    url: jdbc:mysql://mysql_notification:3306/notification_db?useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: notification_user
     password: thisisnotification

--- a/config-repo/notification-service.yml
+++ b/config-repo/notification-service.yml
@@ -7,6 +7,12 @@ spring:
       host: redis
       port: 6379
       password: redis_pw123
+      lettuce:
+        pool:
+          max-active: 50   # 스레드풀 max(8) * 여유(6배)
+          max-idle: 20
+          min-idle: 10
+          max-wait: 3000ms # 커넥션 대기 최대 3초
   kafka:
     consumer:
       bootstrap-servers: kafka:9092
@@ -51,3 +57,16 @@ session:
   key: "dummy-session-key"
 message:
   key: "dummy-message-key"
+
+# pub/sub 전용 Redis (새 인스턴스: redis-pubsub)
+notification:
+  redis:
+    pubsub:
+      host: redis-pubsub   # docker-compose 에 추가할 그 이름
+      port: 6379
+      password: redis_pw123
+      pool:
+        max-active: 50
+        max-idle: 20
+        min-idle: 10
+        max-wait: 3000ms

--- a/docker-compose-msa.yml
+++ b/docker-compose-msa.yml
@@ -180,6 +180,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      redis-pubsub:
+        condition: service_healthy # pubsub용 추가
     environment: # Todo : 제거하기.
       - SPRING_CONFIG_IMPORT=configserver:http://config-service:8888
       - SPRING_JWT_SECRET=vmfhaltmskdlstkfkdgodyrolroqkfwkalskdjqwkjdnkasjlqsssa
@@ -246,7 +248,7 @@ services:
     networks: [voiceprint_net]
     restart: unless-stopped
 
-  # Redis Service (from docker-compose.yml)
+  # Redis Service (session / hget 전용)
   redis:
     container_name: redis
     image: redis:8
@@ -263,6 +265,27 @@ services:
     networks: [voiceprint_net] # Changed network
     healthcheck:
       test: ["CMD-SHELL", "redis-cli -a \"$REDIS_PASSWORD\" ping"]
+      interval: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # Redis Service (pub/sub 전용)
+  redis-pubsub:
+    container_name: redis-pubsub
+    image: redis:8
+    ports:
+      - "6380:6379"   # 호스트에선 6380, 컨테이너 안은 그대로 6379
+    env_file:
+      - ./redis/.env  # 비번 재사용하면 이걸로 충분
+    volumes:
+      - ./redis-pubsub.conf:/usr/local/etc/redis/redis.conf:ro  # 필요하면 별도 conf, 아니면 기존 거 써도 됨
+    command:
+      - /bin/sh
+      - -c
+      - redis-server /usr/local/etc/redis/redis.conf --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"
+    networks: [ voiceprint_net ]
+    healthcheck:
+      test: [ "CMD-SHELL", "redis-cli -a \"$REDIS_PASSWORD\" -p 6379 ping" ]
       interval: 5s
       retries: 10
     restart: unless-stopped

--- a/docker-compose-msa.yml
+++ b/docker-compose-msa.yml
@@ -267,6 +267,25 @@ services:
       retries: 10
     restart: unless-stopped
 
+  # Redis Exporter
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: redis-exporter
+    env_file:
+      - ./redis/.env
+    command:
+      - '--web.listen-address=:9121'
+      - '--web.telemetry-path=/metrics'
+      - '--redis.addr=redis://:redis_pw123@redis:6379' # 왜 .env에서 안 가져와지냐
+    ports:
+      - "9121:9121"
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks: [ voiceprint_net ]
+    restart: unless-stopped
+
+
   # Prometheus
   prometheus:
     image: prom/prometheus

--- a/docker-compose-msa.yml
+++ b/docker-compose-msa.yml
@@ -229,6 +229,23 @@ services:
       retries: 10
     restart: unless-stopped
 
+  # notificationDB exporter
+  mysql-notification-exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: mysql-notification-exporter
+    environment:
+      MYSQLD_EXPORTER_PASSWORD: "exporter_password_notif"
+    command:
+      - "--mysqld.address=mysql_notification:3306"
+      - "--mysqld.username=exporter"
+    depends_on:
+      mysql_notification:
+        condition: service_healthy
+    ports:
+      - "9105:9104"
+    networks: [voiceprint_net]
+    restart: unless-stopped
+
   # Redis Service (from docker-compose.yml)
   redis:
     container_name: redis

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -20,3 +20,8 @@ scrape_configs:
     static_configs:
       - targets: ['notification-service:8081']
         labels: { app: 'alarm', tier: 'svc' }
+
+  - job_name: 'mysql-notification'
+    static_configs:
+      - targets: ['mysql-notification-exporter:9104']
+        labels: { db: 'notification', role: 'primary' }

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,25 +3,37 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
+  # Gateway (Edge Layer)
   - job_name: 'gateway-service' # 쿼리에서 필터할 이름
     metrics_path: /actuator/prometheus  # SpringBoot Actuator가 노출하는 엔드포인트
     static_configs:
       - targets: ['gateway-service:8000']
         labels: { app: 'gateway', tier: 'edge' }
 
+  # Backend Core Service
   - job_name: 'backend-msa'
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['backend-msa:8080']
         labels: { app: 'core', tier: 'svc' }
 
+  # Notification Service
   - job_name: 'notification-service'
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['notification-service:8081']
         labels: { app: 'alarm', tier: 'svc' }
 
+  # MySQL (Notification DB Exporter)
   - job_name: 'mysql-notification'
     static_configs:
       - targets: ['mysql-notification-exporter:9104']
         labels: { db: 'notification', role: 'primary' }
+
+  # Redis Exporter
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis-exporter:9121']
+        labels:
+          db: 'redis'
+          role: 'cache'

--- a/mysql_notification/init/init.sql
+++ b/mysql_notification/init/init.sql
@@ -1,1 +1,12 @@
 CREATE DATABASE IF NOT EXISTS notification_db DEFAULT CHARACTER SET utf8mb4;
+
+-- Create a exporter 전용 유저.
+CREATE USER IF NOT EXISTS 'exporter'@'%' IDENTIFIED BY 'exporter_password_notif';
+
+-- 최소 권한 부여
+GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'exporter'@'%';
+FLUSH PRIVILEGES;
+
+-- 확인
+SELECT User, Host, plugin FROM mysql.user WHERE User='exporter';
+SHOW GRANTS FOR 'exporter'@'%';

--- a/services/backend-msa/Dockerfile
+++ b/services/backend-msa/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod +x gradlew
 RUN ./gradlew clean build -x test --no-daemon
 
 # Spring Boot 앱 실행
-FROM openjdk:21-jdk
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 

--- a/services/config-service/Dockerfile
+++ b/services/config-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 VOLUME /tmp
 ARG JAR_FILE=build/libs/*.jar

--- a/services/discovery-service/Dockerfile
+++ b/services/discovery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 VOLUME /tmp
 ARG JAR_FILE=build/libs/*.jar

--- a/services/gateway-service/Dockerfile
+++ b/services/gateway-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre-alpine
 VOLUME /tmp
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -5,7 +5,7 @@ COPY --chown=gradle:gradle . .
 RUN ./gradlew :services:notification-service:build -x test --no-daemon
 
 # Final App Stage
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-alpine
 WORKDIR /app
 COPY --from=build /home/gradle/src/services/notification-service/build/libs/notification-service-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/RedisSubscriber.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/RedisSubscriber.java
@@ -29,7 +29,6 @@ public class RedisSubscriber implements MessageListener {
         String json = new String(message.getBody(), StandardCharsets.UTF_8);        // 메시지 본문 추출
         log.debug("message.body:{}",message.getBody());
 
-
         // 파싱 : 앞 뒤 \" \" 로 인해 에러 발생. -> 제거
         if (json.startsWith("\"") && json.endsWith("\"")) {
             json = json.substring(1, json.length() -1);
@@ -38,46 +37,28 @@ public class RedisSubscriber implements MessageListener {
 
         NotificationDTO dto = objectMapper.readValue(json, NotificationDTO.class);  // JSON -> DTO
         log.debug("notification dto: {}",dto.getMetadata());
-        log.debug("notification dto: {}",dto.getMessage());
 
-
-        Long notificationId = Long.valueOf(dto.getMetadata().get("notificationId").toString());
-
-        // 재시도 로직 - 없으면 인식을 못함
-        Notification notification = notificationRepositoryPort.findById(notificationId).orElse(null);
-
-        if (notification == null) {
-            log.warn("[RedisSubscriber] 해당 알림 없음: {}", notificationId);
-
-            // 재시도 로직 (100ms * 3회)
-            for (int i = 0; i < 3; i++) {
-                Thread.sleep(100);
-                notification = notificationRepositoryPort.findById(notificationId).orElse(null);
-                log.warn("{}차 조회 : [RedisSubscriber] 해당 알림 없음: {}",i+1, notification);
-
-                if (notification != null) break;
-            }
-            if (notification == null) {
-                log.error("[RedisSubscriber] 재시도 후에도 알림 조회 실패: {}", notificationId);
-                return;
-            }
-        }
-
-        log.info("notificiation : {}",notification);
-        if (notification == null) {
-            log.warn("[RedisSubscriber] 해당 알림 없음: {}", notificationId);
+        // 그냥 메타에서 userId 꺼내 쓰기
+        Object userIdRaw = dto.getMetadata().get("userId");
+        if (userIdRaw == null) {
+            log.error("[RedisSubscriber] userId 메타데이터 없음: {}", dto.getMetadata());
             return;
         }
 
-        Integer userId = notification.getUserId();
-        log.debug("현재 접속중인 emitter : {} ",emitterManager.getAllEmitterIds());
+        Integer userId;
+        if (userIdRaw instanceof Number num) {
+            userId = num.intValue();
+        } else {
+            userId = Integer.valueOf(userIdRaw.toString());
+        }
+
+        log.debug("현재 접속중인 emitter : {} ", emitterManager.getAllEmitterIds());
 
         if (emitterManager.hasEmitter(userId)) {
             emitterManager.sendTo(userId, dto.getType(), dto); // SSE 전송
             log.info("[RedisSubscriber] 실시간 알림 전송 완료: userId={}, type={}", userId, dto.getType());
-        }
-        else {
-            log.info("알림을 전달할 구독자가 접속중이 아닙니다. {}",userId);
+        } else {
+            log.info("알림을 전달할 구독자가 접속중이 아닙니다. {}", userId);
         }
     }
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/RedisSubscriber.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/RedisSubscriber.java
@@ -56,9 +56,9 @@ public class RedisSubscriber implements MessageListener {
 
         if (emitterManager.hasEmitter(userId)) {
             emitterManager.sendTo(userId, dto.getType(), dto); // SSE 전송
-            log.info("[RedisSubscriber] 실시간 알림 전송 완료: userId={}, type={}", userId, dto.getType());
+            log.debug("[RedisSubscriber] 실시간 알림 전송 완료: userId={}, type={}", userId, dto.getType());
         } else {
-            log.info("알림을 전달할 구독자가 접속중이 아닙니다. {}", userId);
+            log.debug("알림을 전달할 구독자가 접속중이 아닙니다. {}", userId);
         }
     }
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
@@ -104,6 +104,25 @@ public class TestController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * JDBC Batch.
+     */
+    @PostMapping("/alarmV6")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger6(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.triggerV6(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
     private List<Integer> parseCsvToInts(String csv) {
         if (csv == null || csv.isBlank()) return List.of();
         return Arrays.stream(csv.split(","))

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
@@ -1,14 +1,53 @@
 package com.voiceprint.notification.adapter.in;
 
+import com.voiceprint.notification.application.service.NotificationTestService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
 @RestController
 @Slf4j
-@RequestMapping("/")
+@RequestMapping("/test")
+@RequiredArgsConstructor
 public class TestController {
+
+    private final NotificationTestService testService;
+
+    /**
+     * 예:
+     * POST /api/notifications/test?time=06:30&limit=500
+     * POST /api/notifications/test?time=06:30&userIds=1,2,3
+     */
+    @PostMapping("/alarm")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.trigger(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
+    private List<Integer> parseCsvToInts(String csv) {
+        if (csv == null || csv.isBlank()) return List.of();
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .toList();
+    }
 
     /**
      * 알림 테스트용 API

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
@@ -24,8 +24,40 @@ public class TestController {
      * POST /api/notifications/test?time=06:30&limit=500
      * POST /api/notifications/test?time=06:30&userIds=1,2,3
      */
-    @PostMapping("/alarm")
-    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger(
+    @PostMapping("/alarmV2")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger2(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.triggerV2(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/alarmV1")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger1(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.triggerV1(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/alarmV3")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger3(
             @RequestParam(value = "time", required = false) String time,
             @RequestParam(value = "limit", required = false) Integer limit,
             @RequestParam(value = "userIds", required = false) String userIdsCsv
@@ -48,6 +80,8 @@ public class TestController {
                 .map(Integer::parseInt)
                 .toList();
     }
+
+
 
     /**
      * 알림 테스트용 API

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
@@ -36,7 +36,7 @@ public class TestController {
 
         List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
 
-        var result = testService.trigger(testTime, limit, onlyUserIds);
+        var result = testService.triggerV3(testTime, limit, onlyUserIds);
         return ResponseEntity.ok(result);
     }
 

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/TestController.java
@@ -72,6 +72,38 @@ public class TestController {
         return ResponseEntity.ok(result);
     }
 
+    @PostMapping("/alarmV4")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger4(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.triggerV4(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/alarmV5")
+    public ResponseEntity<NotificationTestService.NotifyTestResult> trigger5(
+            @RequestParam(value = "time", required = false) String time,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "userIds", required = false) String userIdsCsv
+    ) {
+        LocalTime testTime = (time == null || time.isBlank())
+                ? LocalTime.now().withSecond(0).withNano(0)                       // 기본: 현재 분
+                : LocalTime.parse(time);                                          // "HH:mm" 형식 기대
+
+        List<Integer> onlyUserIds = parseCsvToInts(userIdsCsv);
+
+        var result = testService.triggerV5(testTime, limit, onlyUserIds);
+        return ResponseEntity.ok(result);
+    }
+
     private List<Integer> parseCsvToInts(String csv) {
         if (csv == null || csv.isBlank()) return List.of();
         return Arrays.stream(csv.split(","))

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/AsyncNotificationPublisher.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/AsyncNotificationPublisher.java
@@ -17,6 +17,7 @@ public class AsyncNotificationPublisher {
 
     @Async("notificationExecutor")
     public void publishAllAsync(List<NotificationDTO> dtos) {
+        long pubStart = System.nanoTime();
         for (NotificationDTO dto : dtos) {
             try {
                 redisPublisher.publishNotification(dto);
@@ -24,5 +25,23 @@ public class AsyncNotificationPublisher {
                 log.error("[AsyncNotificationPublisher] publish failed: {}", dto, e);
             }
         }
+        long pubEnd = System.nanoTime();
+        double elapsedMs = (pubEnd - pubStart) / 1_000_000.0;
+        commonLog(elapsedMs);
+    }
+
+    @Async("notificationExecutor")
+    public void publishAllAsyncWithPipeline(List<NotificationDTO> dtos) {
+        long pubStart = System.nanoTime();
+        redisPublisher.publishBatchWithPipeline(dtos);
+        long pubEnd = System.nanoTime();
+        double elapsedMs = (pubEnd - pubStart) / 1_000_000.0;
+
+        commonLog(elapsedMs);
+    }
+
+    private static void commonLog(double elapsedMs) {
+        log.info("[AsyncPublisher] Done. elapsed={}ms, thread={}",
+                String.format("%.2f", elapsedMs), Thread.currentThread().getName());
     }
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/AsyncNotificationPublisher.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/AsyncNotificationPublisher.java
@@ -1,0 +1,28 @@
+package com.voiceprint.notification.adapter.out;
+
+import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AsyncNotificationPublisher {
+
+    private final RedisPublisher redisPublisher;
+
+    @Async("notificationExecutor")
+    public void publishAllAsync(List<NotificationDTO> dtos) {
+        for (NotificationDTO dto : dtos) {
+            try {
+                redisPublisher.publishNotification(dto);
+            } catch (Exception e) {
+                log.error("[AsyncNotificationPublisher] publish failed: {}", dto, e);
+            }
+        }
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/RedisPublisher.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/RedisPublisher.java
@@ -5,16 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisPublisher {
+
+    @Qualifier("pubsubRedisTemplate")
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
+    // 단건 버전 publisher
     public void publishNotification(NotificationDTO dto) {
         try {
             String json = objectMapper.writeValueAsString(dto);
@@ -26,4 +33,31 @@ public class RedisPublisher {
             log.error("[RedisPublisher] 직렬화 실패", e);
         }
     }
+
+    // 배치 + 파이프라인 버전
+    public void publishBatchWithPipeline(List<NotificationDTO> dtos) {
+
+        long start = System.nanoTime();
+
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            var stringSerializer = redisTemplate.getStringSerializer();
+            byte[] channelBytes = stringSerializer.serialize("notification-channel");
+
+            for (NotificationDTO dto : dtos) {
+                try {
+                    String json = objectMapper.writeValueAsString(dto);
+                    byte[] messageBytes = stringSerializer.serialize(json);
+                    connection.publish(channelBytes, messageBytes);
+                } catch (JsonProcessingException e) {
+                    log.warn("[RedisPublisher] serialize failed: {}", dto, e);
+                }
+            }
+            return null;
+        });
+
+        long end = System.nanoTime();
+        double elapsedMs = (end - start) / 1_000_000.0;
+        log.info("[RedisPublisher] pipeline publish {} rows took {}ms", dtos.size(), elapsedMs);
+    }
+
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/NotificationJdbcRepository.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/NotificationJdbcRepository.java
@@ -1,0 +1,69 @@
+package com.voiceprint.notification.adapter.out.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.voiceprint.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    // JPAEntity 기준 SQL.
+    private static final String INSERT_SQL =
+            """
+            INSERT INTO notifications
+            (user_id, type, message, metadata, is_read, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """;
+
+    public void saveAllBatch(List<NotificationJpaEntity> notifications) {
+        long start = System.nanoTime(); // 타이머
+
+        jdbcTemplate.batchUpdate(INSERT_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                NotificationJpaEntity n = notifications.get(i);
+                ps.setInt(1, n.getUserId());
+                ps.setString(2, n.getType());
+                ps.setString(3, n.getMessage());
+                try {
+                    String metadataJson = (n.getMetadata()==null)
+                            ? null
+                            : objectMapper.writeValueAsString(n.getMetadata());
+                    ps.setString(4, metadataJson);
+                } catch (JsonProcessingException e) {
+                    // 메타데이터 직렬화 실패 시 최소한 빈 JSON이라도 저장
+                    log.error("Failed to serialize metadata for notification: {}", n, e);
+                    ps.setString(4, "{}");
+                }
+                ps.setBoolean(5, n.isRead());
+                LocalDateTime createdAt = n.getCreatedAt();
+                if (createdAt == null) createdAt = LocalDateTime.now();
+                ps.setObject(6, createdAt);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return notifications.size();
+            }
+        });
+
+        long end = System.nanoTime();
+        log.info("[NotificationJdbcRepository] batch insert {} rows took {} ms",
+                notifications.size(), (end - start) / 1_000_000);
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/UserNotificationPreferenceJpaEntity.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/UserNotificationPreferenceJpaEntity.java
@@ -27,7 +27,7 @@ public class UserNotificationPreferenceJpaEntity {
     private Integer userId;
 
     @Column(nullable = false)
-    private Boolean enableAlarms;
+    private Boolean enableAlarms = false;
 
     private LocalTime alarmTime;
 

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/UserNotificationPreferenceRepository.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/persistence/UserNotificationPreferenceRepository.java
@@ -1,8 +1,21 @@
 package com.voiceprint.notification.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserNotificationPreferenceRepository extends JpaRepository<UserNotificationPreferenceJpaEntity, Long> {
     Optional<UserNotificationPreferenceJpaEntity> findByUserId(Integer userId);
+
+    List<UserNotificationPreferenceJpaEntity> findByEnableAlarmsTrueAndAlarmTime(LocalTime alarmTime);
+
+
+    List<UserNotificationPreferenceJpaEntity> findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(
+            LocalTime alarmTime, Collection<Integer> userIds
+    );
+
+    List<UserNotificationPreferenceJpaEntity> findByEnableAlarmsTrue();
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/redis/SessionStatusReader.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/out/redis/SessionStatusReader.java
@@ -1,0 +1,64 @@
+package com.voiceprint.notification.adapter.out.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class SessionStatusReader {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String SESSION_KEY_PREFIX = "session";
+
+    /**
+     * 단일 유저 status 조회 (기존 방식 그대로)
+     */
+    public String getStatus(Integer userId) {
+        String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+        Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+        return (statusObj != null)
+                ? statusObj.toString().replace("\"", "")
+                : "NOT_EXIST";
+    }
+
+    /**
+     * 여러 userId에 대해 status를 한 번의 pipeline으로 가져오는 메서드
+     */
+    public Map<Integer, String> getStatusesWithPipeline(List<Integer> userIds) {
+        List<Object> rawResults = redisTemplate.executePipelined(
+                // pipeline 안에서 실행할 명령을 정의하는 콜백
+                new SessionCallback<Object>() {
+                    @Override
+                    public Object execute(RedisOperations operations) throws DataAccessException {
+                        // 이 안의 모든 명령이 한 "파이프라인 세션"으로 묶임
+                        for (Integer userId : userIds) {
+                            String key = SESSION_KEY_PREFIX + ":" + userId;
+                            operations.opsForHash().get(key, "status");
+                        }
+                        return null; // 결과는 executePipelined가 감싼 리스트로 반환
+                    }
+                }
+        );
+
+        Map<Integer, String> result = new HashMap<>(userIds.size());
+        for (int i = 0; i < userIds.size(); i++) {
+            Integer userId = userIds.get(i);
+            Object raw = rawResults.get(i);
+
+            String status = (raw != null)
+                    ? raw.toString().replace("\"", "")
+                    : "NOT_EXIST";
+
+            result.put(userId, status);
+        }
+        return result;
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/port/in/NotificationCommandPort.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/port/in/NotificationCommandPort.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface NotificationCommandPort {
     void sendAndSave(UserNotificationPreferenceJpaEntity user, NotificationDTO dto);
 
+    void sendAndSaveWithBatch(UserNotificationPreferenceJpaEntity user, NotificationDTO dto);
+
     void sendAndSaveWithNewTransaction(UserNotificationPreferenceJpaEntity user, NotificationDTO dto);
 
     void markNotification(Integer userId, Long notificationId);

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/port/in/NotificationCommandPort.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/port/in/NotificationCommandPort.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface NotificationCommandPort {
     void sendAndSave(UserNotificationPreferenceJpaEntity user, NotificationDTO dto);
 
+    void sendAndSaveWithNewTransaction(UserNotificationPreferenceJpaEntity user, NotificationDTO dto);
+
     void markNotification(Integer userId, Long notificationId);
 
     void publishAllNotifications(List<Notification> notifications);

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/DiaryReminderScheduler.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/DiaryReminderScheduler.java
@@ -11,11 +11,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -26,68 +23,38 @@ public class DiaryReminderScheduler {
     private final RedisTemplate<String, String> redisTemplate;
     private final NotificationService notificationService;
     private final UserNotificationPreferenceRepository userNotificationPreferenceRepository;
+    private final NotificationMessageFactory notificationMessageFactory;
 
     @Value("${session.key}")
     private String session_key;
 
-    @Scheduled(cron = "0 * * * * *") // 1분 마다 실행
+    @Scheduled(cron = "0 */30 * * * *", zone = "Asia/Seoul") // 30분 마다 실행
     public void checkAndNotify() {
         LocalTime now = LocalTime.now().withSecond(0).withNano(0); // '초'단위 이하 제거.
         int minute = now.getMinute();
 
         // 0 or 30분일 때만 실행
-//        if (minute != 0 && minute !=30) return;
+        if (minute != 0 && minute !=30) return;
 
-//        log.info("🕒 리마인더 스케줄러 실행 시작: {}", now);
+        log.info("🕒 리마인더 스케줄러 실행 시작: {}", now);
 
         notifyIndividualUsers(now);
 //        notifyGroupUsers(now);
     }
 
-//    private void notifyGroupUsers(LocalTime now) {
-//        DayOfWeek today = LocalDateTime.now().getDayOfWeek();
-//
-//        // 그룹 리포지토리로부터 해당 시간에 알람 설정된 그룹들 가져오기
-//        List<GroupJpaEntity> candidateGroups = groupRepository.findByAlarmTimeAndEnableAlarmTrue(now);
-//
-//        // 요일 조건 필터링
-//        List<GroupJpaEntity> targetGroups = candidateGroups.stream()
-//                .filter(g -> g.getAlarmDays() != null && g.getAlarmDays().contains(today))
-//                .toList();
-//
-//        for (GroupJpaEntity group : targetGroups) {
-//            List<UserJPAEntity> members = userRepository.findAlarmEnabledUsersByGroup(group); // 알람 켠 멤버만
-//
-//            for (UserJPAEntity user : members) {
-//                NotificationDTO dto = new NotificationDTO(
-//                        "groupReminder",
-//                        String.format("%s 그룹의 공유 시간이 다가왔어요!! 일기를 공유하고 친구들과 일상을 공유하세요!", group.getName()),
-//                        Map.of(
-//                                "groupId", group.getId()
-//                        )
-//                );
-//
-//                try {
-//                    notificationService.sendAndSave(user, dto);
-//                    log.info("[그룹 알림 전송] userId={}, groupId={}", user.getId(), group.getId());
-//                } catch (Exception e) {
-//                    log.error("[그룹 알림 실패] userId={}, groupId={}, err={}", user.getId(), group.getId(), e.getMessage());
-//                }
-//            }
-//        }
-//    }
-
     private void notifyIndividualUsers(LocalTime now) {
+        // 모든 유저 탐색
         List<UserNotificationPreferenceJpaEntity> users = userNotificationPreferenceRepository.findAll();
 
+        // 유저마다 알림 생성 및 처리.
         for (UserNotificationPreferenceJpaEntity user : users) {
             try {
-//                log.debug("userId : {}", user.getId());
-                // null 체크 유의.
+                log.debug("userId : {}", user.getId());
+
                 if (user.getAlarmTime() == null ||
                         !Boolean.TRUE.equals(user.getEnableAlarms()) ||
                         !user.getAlarmTime().equals(now)) {
-//                    log.debug("패스");
+
                     continue;  // 알람 시간 없음, 알람 꺼짐, 알람 시각 아님 → 패스
                 }
 
@@ -100,38 +67,17 @@ public class DiaryReminderScheduler {
 
                 if (hasStatus != null || hasStatus) {
                     Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
-                    status = (statusObj != null) ? statusObj.toString().replaceAll("\"", "") : "NOT_EXIST";                    log.debug("status : {}",status);
+                    status = (statusObj != null) ? statusObj.toString().replaceAll("\"", "") : "NOT_EXIST";
+                    log.debug("status : {}",status);
                 }
 
-                NotificationDTO payload = switch (status) {
-                    case "WAITING", "NOT_EXIST" -> new NotificationDTO(
-                            "reminder",
-                            "오늘은 일기 쓰셨나요? 말자국으로 오늘 하루를 기록해 보세요!!",
-                            Map.of("status", status)
-                    );
-                    case "IN_PROGRESS" -> new NotificationDTO(
-                            "reminder",
-                            "대화가 아직 진행중이에요. 대화를 완료하고 일기를 생성해주세요!",
-                            Map.of("status", status)
-                    );
-                    case "DIARY_DONE", "DIARY_CREATING" -> new NotificationDTO(
-                            "reminder", "생성된 일기가 있어요. 저장을 잊지 마세요!",
-                            Map.of("status", status)
-                    );
-                    case "ERROR" -> new NotificationDTO(
-                            "reminder", "일기 저장 중 오류가 발생했어요!",
-                            Map.of("status", status)
-                    );
-                    default -> null; // DIARY_SAVED 알림 없음
-                };
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
                 log.debug("payload : {}",payload);
-
 
                 if (payload != null) {
                     try {
                         notificationService.sendAndSave(user, payload);
-
-                        log.info("[알림 저장 및 전송 완료] userId={}, status={}", userId, status);
+                        log.debug("[알림 저장 및 전송 완료] userId={}, status={}", userId, status);
                     } catch (Exception e) {
                         log.error("[알림 전송 실패] userId={}, error={}", userId, e.getMessage());
                     }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationMessageFactory.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationMessageFactory.java
@@ -1,0 +1,7 @@
+package com.voiceprint.notification.application.service;
+
+import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
+
+public interface NotificationMessageFactory {
+    NotificationDTO createNotification(String status);
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationPerfMonitor.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationPerfMonitor.java
@@ -1,0 +1,69 @@
+package com.voiceprint.notification.application.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 알림 생성 및 전송 중
+ * redis, MySQL에 쓰이는 시간.
+ */
+@Component
+@Slf4j
+public class NotificationPerfMonitor {
+
+    private final AtomicLong redisGetNanos = new AtomicLong();
+    private final AtomicLong redisPublishNanos = new AtomicLong();
+    private final AtomicLong dbReadNanos = new AtomicLong();
+    private final AtomicLong dbInsertNanos = new AtomicLong();
+
+    //reset 메서드
+    public void reset() {
+        redisGetNanos.set(0L);
+        redisPublishNanos.set(0L);
+        dbReadNanos.set(0L);
+        dbInsertNanos.set(0L);
+    }
+
+    public void addRedisGet(long nanos) {
+        redisGetNanos.addAndGet(nanos);
+    }
+
+    public void addRedisPublish(long nanos) {
+        redisPublishNanos.addAndGet(nanos);
+    }
+
+    public void addDbRead(long nanos) {
+        dbReadNanos.addAndGet(nanos);
+    }
+
+    public void addDbInsert(long nanos) {
+        dbInsertNanos.addAndGet(nanos);
+    }
+
+    public void logSummary(String tag, long totalMs, int totalUsers, int sent, int skipped) {
+        long redisGetMs   = redisGetNanos.get()      / 1_000_000L;
+        long redisPubMs   = redisPublishNanos.get()  / 1_000_000L;
+        long dbReadMs     = dbReadNanos.get()        / 1_000_000L;
+        long dbInsertMs   = dbInsertNanos.get()      / 1_000_000L;
+
+        double base = totalMs > 0 ? totalMs : 1.0;
+
+        double rGetPct = redisGetMs  * 100.0 / base;
+        double rPubPct = redisPubMs  * 100.0 / base;
+        double dReadPct = dbReadMs   * 100.0 / base;
+        double dInsPct = dbInsertMs  * 100.0 / base;
+
+        log.info(
+                "[PERF][{}] total={}ms | users={} | sent={} | skipped={} | " +
+                        "redis_get={}ms({}%) | redis_publish={}ms({}%) | db_read={}ms({}%) | db_insert={}ms({}%)",
+                tag,
+                totalMs, totalUsers, sent, skipped,
+                redisGetMs,  String.format("%.1f", rGetPct),
+                redisPubMs,  String.format("%.1f", rPubPct),
+                dbReadMs,    String.format("%.1f", dReadPct),
+                dbInsertMs,  String.format("%.1f", dInsPct)
+        );
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -69,12 +69,12 @@ public class NotificationService implements NotificationCommandPort, Notificatio
 
                 // 1) Redis에서 상태 조회
                 long rStart = System.nanoTime();
-                String status = "NOT_EXIST";
-                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
-                if (Boolean.TRUE.equals(hasStatus)) {
-                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
-                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
-                }
+
+                // Hget은 key가 없을 경우, null 반환.
+                Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                String status = (statusObj != null)
+                        ? statusObj.toString().replace("\"", "")
+                        : "NOT_EXIST";
                 long rEnd = System.nanoTime();
                 perfMonitor.addRedisGet(rEnd - rStart);
 

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -13,11 +13,11 @@ import com.voiceprint.notification.application.port.in.NotificationQueryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +40,38 @@ public class NotificationService implements NotificationCommandPort, Notificatio
      */
     @Override
     public void sendAndSave(UserNotificationPreferenceJpaEntity user, NotificationDTO dto) {
+        Notification notification = Notification.create(
+                user.getUserId(),
+                dto.getType(),
+                dto.getMessage(),
+                dto.getMetadata()
+        );
+        Notification savedNotification = notificationPort.save(notification);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                NotificationDTO inputDto = new NotificationDTO(
+                        dto.getType(),
+                        dto.getMessage(),
+                        Map.of(
+                                "notificationId", savedNotification.getId(),
+                                "userId", user.getId()
+                        )
+                );
+                redisPublisher.publishNotification(inputDto);
+            }
+        });
+    }
+
+    /**
+     * 알림 생성 + DB 저장 + Redis Pub/Sub 전송
+     *
+     * Transaction 전파를 REQUIRES_NEW로 명시 : 커밋과 publish 단건으로 즉시 처리됨.
+     */
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendAndSaveWithNewTransaction(UserNotificationPreferenceJpaEntity user, NotificationDTO dto) {
         Notification notification = Notification.create(
                 user.getUserId(),
                 dto.getType(),

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.voiceprint.notification.application.service;
 
 import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
 import com.voiceprint.notification.adapter.in.web.dto.NotificationListWithCursorDTO;
+import com.voiceprint.notification.adapter.out.AsyncNotificationPublisher;
 import com.voiceprint.notification.adapter.out.RedisPublisher;
 import com.voiceprint.notification.adapter.out.persistence.*;
 import com.voiceprint.notification.application.port.out.NotificationRepositoryPort;
@@ -38,13 +39,109 @@ public class NotificationService implements NotificationCommandPort, Notificatio
     private final NotificationMapper notificationMapper;
     private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
     private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
-
+    private final NotificationJdbcRepository notificationJdbcRepository;
+    private final AsyncNotificationPublisher asyncNotificationPublisher; // @Async로 Redis publish
     private final NotificationPerfMonitor perfMonitor;                    // 성능 측정용
 
     private static final String SESSION_KEY_PREFIX = "session";
 
     @PersistenceContext
     EntityManager em;
+
+
+    // JDBC 배치 기반 알림 처리.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BatchResult processBatchWithJdbc(List<UserNotificationPreferenceJpaEntity> batch) {
+
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        List<NotificationJpaEntity> entities = new ArrayList<>();
+        List<NotificationDTO> publishDtos = new ArrayList<>();
+
+        long batchStart = System.currentTimeMillis();
+
+        for (UserNotificationPreferenceJpaEntity user : batch) {
+            try {
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                // 1) Redis에서 상태 조회
+                long rStart = System.nanoTime();
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
+
+                // 2) status 기반으로 알림 메시지 생성
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // 3) 메타데이터(userId 포함) 구성
+                Map<String, Object> meta = new HashMap<>();
+                if (payload.getMetadata() != null) {
+                    meta.putAll(payload.getMetadata());
+                }
+                meta.put("userId", userId);   // subscriber가 이걸로 SSE 보냄
+
+                // 4) DB insert용 엔티티 구성
+                NotificationJpaEntity entity = NotificationJpaEntity.create(
+                        userId,
+                        payload.getType(),
+                        payload.getMessage(),
+                        meta
+                );
+                entities.add(entity);
+
+                // 5) Redis publish용 DTO도 같이 적재
+                NotificationDTO publishDto = new NotificationDTO(
+                        payload.getType(),
+                        payload.getMessage(),
+                        meta
+                );
+                publishDtos.add(publishDto);
+
+                sent++;
+
+            } catch (Exception e) {
+                log.error("Error processing user {} during JDBC batch", user.getUserId(), e);
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        // 6) JDBC 배치 INSERT (entities가 있을 때만)
+        if (!entities.isEmpty()) {
+            long saveStart = System.nanoTime();
+            notificationJdbcRepository.saveAllBatch(entities);
+            long saveEnd = System.nanoTime();
+            perfMonitor.addDbInsert(saveEnd - saveStart);
+
+            // 7) 커밋 후 Async로 Redis publish
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    long pubStart = System.nanoTime();
+                    asyncNotificationPublisher.publishAllAsync(publishDtos);
+                    long pubEnd = System.nanoTime();
+                    perfMonitor.addRedisPublish(pubEnd - pubStart);
+                }
+            });
+        }
+
+        long batchEnd = System.currentTimeMillis();
+        log.info("[BATCH][JDBC] size={} took={}ms, sent={}, skipped={}",
+                batch.size(), (batchEnd - batchStart), sent, skipped);
+
+        return new BatchResult(sent, skipped, errors);
+    }
 
     // V3 실험 B: Redis GET + DB insert만 (publish 제거) //TODO :테스트용
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -279,7 +279,7 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                 if (metadata != null) {
                     meta.putAll(metadata);
                 }
-                meta.put("notificationId", entity.getId());
+//                meta.put("notificationId", entity.getId()); // JPA -> JDBCTemplate 변경 예정
                 meta.put("userId", userId);
 
                 NotificationDTO inputDto = new NotificationDTO(

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -5,6 +5,7 @@ import com.voiceprint.notification.adapter.in.web.dto.NotificationListWithCursor
 import com.voiceprint.notification.adapter.out.AsyncNotificationPublisher;
 import com.voiceprint.notification.adapter.out.RedisPublisher;
 import com.voiceprint.notification.adapter.out.persistence.*;
+import com.voiceprint.notification.adapter.out.redis.SessionStatusReader;
 import com.voiceprint.notification.application.port.out.NotificationRepositoryPort;
 import com.voiceprint.notification.domain.Notification;
 import com.voiceprint.notification.application.port.in.NotificationCommandPort;
@@ -40,8 +41,9 @@ public class NotificationService implements NotificationCommandPort, Notificatio
     private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
     private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
     private final NotificationJdbcRepository notificationJdbcRepository;
-    private final AsyncNotificationPublisher asyncNotificationPublisher; // @Async로 Redis publish
+    private final AsyncNotificationPublisher asyncNotificationPublisher;  // @Async로 Redis publish
     private final NotificationPerfMonitor perfMonitor;                    // 성능 측정용
+    private final SessionStatusReader sessionStatusReader;                //
 
     private static final String SESSION_KEY_PREFIX = "session";
 
@@ -62,21 +64,21 @@ public class NotificationService implements NotificationCommandPort, Notificatio
 
         long batchStart = System.currentTimeMillis();
 
+        // userId 리스트 생성
+        List<Integer> userIds = batch.stream()
+                .map(UserNotificationPreferenceJpaEntity::getUserId)
+                .toList();
+
+        // Redis Pipeline 활용.
+        long rStart = System.nanoTime();
+        Map<Integer, String> statusMap = sessionStatusReader.getStatusesWithPipeline(userIds);
+        long rEnd = System.nanoTime();
+        perfMonitor.addRedisGet(rEnd - rStart);
+
         for (UserNotificationPreferenceJpaEntity user : batch) {
             try {
                 Integer userId = user.getUserId();
-                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
-
-                // 1) Redis에서 상태 조회
-                long rStart = System.nanoTime();
-
-                // Hget은 key가 없을 경우, null 반환.
-                Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
-                String status = (statusObj != null)
-                        ? statusObj.toString().replace("\"", "")
-                        : "NOT_EXIST";
-                long rEnd = System.nanoTime();
-                perfMonitor.addRedisGet(rEnd - rStart);
+                String status = statusMap.getOrDefault(userId, "NOT_EXIST");
 
                 // 2) status 기반으로 알림 메시지 생성
                 NotificationDTO payload = notificationMessageFactory.createNotification(status);

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -39,17 +39,22 @@ public class NotificationService implements NotificationCommandPort, Notificatio
     private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
     private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
 
+    private final NotificationPerfMonitor perfMonitor;                    // 성능 측정용
+
     private static final String SESSION_KEY_PREFIX = "session";
+
     @PersistenceContext
     EntityManager em;
 
-    //1000개 배치 단위로 별도 트랜잭션
+    // --- V3용: 1000개 배치 단위로 REQUIRES_NEW ---
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public BatchResult processBatchWithNewTransaction(List<UserNotificationPreferenceJpaEntity> batch) {
 
         int sent = 0;
         int skipped = 0;
         List<String> errors = new ArrayList<>();
+
+        long batchStart = System.currentTimeMillis();
 
         for (UserNotificationPreferenceJpaEntity user : batch) {
             try {
@@ -58,13 +63,17 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                 Integer userId = user.getUserId();
                 String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
 
+                long rStart = System.nanoTime();
+
                 String status = "NOT_EXIST";
                 Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
-
                 if (Boolean.TRUE.equals(hasStatus)) {
                     Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
                     status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
                 }
+
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
 
                 NotificationDTO payload = notificationMessageFactory.createNotification(status);
                 if (payload == null) {
@@ -86,6 +95,10 @@ public class NotificationService implements NotificationCommandPort, Notificatio
         // - em.flush() 자동 호출
         // - 여기까지 persist 된 알림들이 한 번에 INSERT
         // - 이 트랜잭션에서 registerSynchronization 한 afterCommit 콜백들 실행 → Redis publish
+
+        long batchEnd = System.currentTimeMillis();
+        log.info("[BATCH][V3] size={} took={}ms, sent={}, skipped={}",
+                batch.size(), (batchEnd - batchStart), sent, skipped);
 
         return new BatchResult(sent, skipped, errors);
     }
@@ -140,7 +153,11 @@ public class NotificationService implements NotificationCommandPort, Notificatio
         );
         NotificationJpaEntity entity = notificationMapper.toJpaEntity(notification);
 
+        // === db insert 측정
+        long saveStart = System.nanoTime();
         em.persist(entity); // JPA가 INSERT 쿼리 쌓아둠 (의도)
+        long saveEnd = System.nanoTime();
+        perfMonitor.addDbInsert(saveEnd - saveStart);
 
         final Integer userId = user.getUserId();
         final String type = dto.getType();
@@ -163,8 +180,10 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                         message,
                         meta
                 );
-
+                long pubStart = System.nanoTime();
                 redisPublisher.publishNotification(inputDto);
+                long pubEnd = System.nanoTime();
+                perfMonitor.addRedisPublish(pubEnd - pubStart);
             }
         });
     }
@@ -183,7 +202,12 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                 dto.getMessage(),
                 dto.getMetadata()
         );
+
+        // DB insert 시간 측정
+        long saveStart = System.nanoTime();
         Notification savedNotification = notificationPort.save(notification);
+        long saveEnd = System.nanoTime();
+        perfMonitor.addDbInsert(saveEnd - saveStart);
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
@@ -196,7 +220,11 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                                 "userId", user.getId()
                         )
                 );
+
+                long pubStart = System.nanoTime();
                 redisPublisher.publishNotification(inputDto);
+                long pubEnd = System.nanoTime();
+                perfMonitor.addRedisPublish(pubEnd - pubStart);
             }
         });
     }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -131,7 +131,7 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                 @Override
                 public void afterCommit() {
                     long pubStart = System.nanoTime();
-                    asyncNotificationPublisher.publishAllAsync(publishDtos);
+                    asyncNotificationPublisher.publishAllAsyncWithPipeline(publishDtos);
                     long pubEnd = System.nanoTime();
                     perfMonitor.addRedisPublish(pubEnd - pubStart);
                 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -3,21 +3,24 @@ package com.voiceprint.notification.application.service;
 import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
 import com.voiceprint.notification.adapter.in.web.dto.NotificationListWithCursorDTO;
 import com.voiceprint.notification.adapter.out.RedisPublisher;
-import com.voiceprint.notification.adapter.out.persistence.ProcessedEventJPARepository;
-import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceJpaEntity;
-import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceRepository;
+import com.voiceprint.notification.adapter.out.persistence.*;
 import com.voiceprint.notification.application.port.out.NotificationRepositoryPort;
 import com.voiceprint.notification.domain.Notification;
 import com.voiceprint.notification.application.port.in.NotificationCommandPort;
 import com.voiceprint.notification.application.port.in.NotificationQueryPort;
+import com.voiceprint.notification.dto.BatchResult;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +35,60 @@ public class NotificationService implements NotificationCommandPort, Notificatio
 
     private final NotificationRepositoryPort notificationPort;
     private final RedisPublisher redisPublisher;
-    private final UserNotificationPreferenceRepository userNotificationPreferenceRepository;
-    private final ProcessedEventJPARepository processedEventRepository;
+    private final NotificationMapper notificationMapper;
+    private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
+    private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
+
+    private static final String SESSION_KEY_PREFIX = "session";
+    @PersistenceContext
+    EntityManager em;
+
+    //1000개 배치 단위로 별도 트랜잭션
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BatchResult processBatchWithNewTransaction(List<UserNotificationPreferenceJpaEntity> batch) {
+
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (UserNotificationPreferenceJpaEntity user : batch) {
+            try {
+                // (1) 여기로 Redis 상태 조회 로직을 옮기거나,
+                //     혹은 DTO 를 바깥에서 만들어서 넘겨줘도 됨.
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // (2) 기존의 배치용 메소드 재사용
+                sendAndSaveWithBatch(user, payload);
+                sent++;
+
+            } catch (Exception e) {
+                log.error("Error processing user {} during notification batch", user.getUserId(), e);
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        // 이 메소드가 끝날 때 트랜잭션 커밋:
+        // - em.flush() 자동 호출
+        // - 여기까지 persist 된 알림들이 한 번에 INSERT
+        // - 이 트랜잭션에서 registerSynchronization 한 afterCommit 콜백들 실행 → Redis publish
+
+        return new BatchResult(sent, skipped, errors);
+    }
 
     /**
      * 알림 생성 + DB 저장 + Redis Pub/Sub 전송
@@ -59,6 +114,56 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                                 "userId", user.getId()
                         )
                 );
+                redisPublisher.publishNotification(inputDto);
+            }
+        });
+    }
+
+    // 배치 경계에서 호출할 flush/clear
+    public void flushAndClear() {
+        em.flush();  // 쌓여있는 INSERT/UPDATE를 DB로 실제 전송
+        em.clear();  // 1차 캐시 비우기 (메모리 절약)
+    }
+
+    /**
+     * 알림 생성 + DB 저장 + Redis Pub/Sub 전송
+     *
+     * 배치 처리할 경우, 즉시 getId 가 되지 않기에 처리한 로직
+     */
+    @Override
+    public void sendAndSaveWithBatch(UserNotificationPreferenceJpaEntity user, NotificationDTO dto) {
+        Notification notification = Notification.create(
+                user.getUserId(),
+                dto.getType(),
+                dto.getMessage(),
+                dto.getMetadata()
+        );
+        NotificationJpaEntity entity = notificationMapper.toJpaEntity(notification);
+
+        em.persist(entity); // JPA가 INSERT 쿼리 쌓아둠 (의도)
+
+        final Integer userId = user.getUserId();
+        final String type = dto.getType();
+        final String message = dto.getMessage();
+        final Map<String, Object> metadata = dto.getMetadata();
+
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                Map<String, Object> meta = new HashMap<>();
+                if (metadata != null) {
+                    meta.putAll(metadata);
+                }
+                meta.put("notificationId", entity.getId());
+                meta.put("userId", userId);
+
+                NotificationDTO inputDto = new NotificationDTO(
+                        type,
+                        message,
+                        meta
+                );
+
                 redisPublisher.publishNotification(inputDto);
             }
         });
@@ -172,4 +277,6 @@ public class NotificationService implements NotificationCommandPort, Notificatio
     public void updateNotificationMetadata(List<Notification> notifications) {
         log.warn("updateNotificationMetadata method needs implementation using NotificationPort.");
     }
+
+
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationService.java
@@ -46,6 +46,95 @@ public class NotificationService implements NotificationCommandPort, Notificatio
     @PersistenceContext
     EntityManager em;
 
+    // V3 실험 B: Redis GET + DB insert만 (publish 제거) //TODO :테스트용
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BatchResult processBatchRedisAndDbNoPublish(List<UserNotificationPreferenceJpaEntity> batch) {
+
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (UserNotificationPreferenceJpaEntity user : batch) {
+            try {
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                // Redis GET 계측
+                long rStart = System.nanoTime();
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
+
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // DB insert (publish 없음)
+                sendAndSaveWithBatchNoPublish(user, payload);
+                sent++;
+
+            } catch (Exception e) {
+                log.error("Error processing user {} during V3-Redis+DbNoPub", user.getUserId(), e);
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        return new BatchResult(sent, skipped, errors);
+    }
+
+
+    // V3 실험 A: Redis GET만 있는 버전 : TODO: 테스트용
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public BatchResult processBatchRedisOnly(List<UserNotificationPreferenceJpaEntity> batch) {
+
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (UserNotificationPreferenceJpaEntity user : batch) {
+            try {
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                long rStart = System.nanoTime();
+
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
+
+                // DTO 만들긴 하는데 DB 저장은 안 함
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // DB insert / publish 없음
+                sent++;
+
+            } catch (Exception e) {
+                log.error("Error processing user {} during V3-RedisOnly", user.getUserId(), e);
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        return new BatchResult(sent, skipped, errors);
+    }
+
+
     // --- V3용: 1000개 배치 단위로 REQUIRES_NEW ---
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public BatchResult processBatchWithNewTransaction(List<UserNotificationPreferenceJpaEntity> batch) {
@@ -71,7 +160,6 @@ public class NotificationService implements NotificationCommandPort, Notificatio
                     Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
                     status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
                 }
-
                 long rEnd = System.nanoTime();
                 perfMonitor.addRedisGet(rEnd - rStart);
 
@@ -137,6 +225,25 @@ public class NotificationService implements NotificationCommandPort, Notificatio
         em.flush();  // 쌓여있는 INSERT/UPDATE를 DB로 실제 전송
         em.clear();  // 1차 캐시 비우기 (메모리 절약)
     }
+
+    // publish 없는 배치 insert 전용
+    public void sendAndSaveWithBatchNoPublish(UserNotificationPreferenceJpaEntity user, NotificationDTO dto) {
+        Notification notification = Notification.create(
+                user.getUserId(),
+                dto.getType(),
+                dto.getMessage(),
+                dto.getMetadata()
+        );
+        NotificationJpaEntity entity = notificationMapper.toJpaEntity(notification);
+
+        long saveStart = System.nanoTime();
+        em.persist(entity);
+        long saveEnd = System.nanoTime();
+        perfMonitor.addDbInsert(saveEnd - saveStart);
+
+        // afterCommit 등록 안 함 => Redis publish 없음
+    }
+
 
     /**
      * 알림 생성 + DB 저장 + Redis Pub/Sub 전송

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -30,6 +30,7 @@ public class NotificationTestService {
     private final NotificationService notificationService;                // 실제 알림 저장 및 전송 처리
     private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
     private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
+    private final NotificationPerfMonitor perfMonitor;
 
     private static final String SESSION_KEY_PREFIX = "session";
     private static final int BATCH_SIZE = 1000;
@@ -37,17 +38,21 @@ public class NotificationTestService {
     @Transactional(readOnly = false)
     public NotifyTestResult triggerV3(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
 
-        List<UserNotificationPreferenceJpaEntity> targets;
+        perfMonitor.reset();
+        long totalStartMs = System.currentTimeMillis();
 
+        long dbReadStart = System.nanoTime();
+        List<UserNotificationPreferenceJpaEntity> targets;
         if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
             targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
         } else {
             targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
         }
-
         if (limit != null && limit > 0 && targets.size() > limit) {
             targets = targets.subList(0, limit);
         }
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
 
         int total = targets.size();
         int sent = 0;
@@ -74,6 +79,10 @@ public class NotificationTestService {
         // 마지막 잔여분 처리
         notificationService.flushAndClear();
 
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V3", totalMs, total, sent, skipped);
         return new NotifyTestResult(testTime, total, sent, skipped, errors);
     }
     /**
@@ -84,6 +93,10 @@ public class NotificationTestService {
      */
     @Transactional(readOnly = false)
     public NotifyTestResult triggerV2(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+        perfMonitor.reset();
+
+        long totalStartMs = System.currentTimeMillis();
+        long dbReadStart = System.nanoTime();
 
         List<UserNotificationPreferenceJpaEntity> targets;
 
@@ -96,18 +109,22 @@ public class NotificationTestService {
         if (limit != null && limit > 0 && targets.size() > limit) {
             targets = targets.subList(0, limit);
         }
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
 
         int total = targets.size();
         int sent = 0;
         int skipped = 0;
         List<String> errors = new ArrayList<>();
-
         int processed = 0;
 
         for (UserNotificationPreferenceJpaEntity user : targets) {
             try {
                 Integer userId = user.getUserId();
                 String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                // --- Redis 상태 조회 시간 측정 ---
+                long rStart = System.nanoTime();
 
                 String status = "NOT_EXIST";
                 Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
@@ -116,13 +133,15 @@ public class NotificationTestService {
                     Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
                     status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
                 }
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
 
                 NotificationDTO payload = notificationMessageFactory.createNotification(status);
-
                 if (payload == null) {
                     skipped++;
                     continue;
                 }
+
 
                 // JPA Batch 버전: persist만 쌓아두고, afterCommit에서 Redis 발행
                 notificationService.sendAndSaveWithBatch(user, payload);
@@ -143,6 +162,11 @@ public class NotificationTestService {
         // 마지막 잔여분 처리
         notificationService.flushAndClear();
 
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V2", totalMs, total, sent, skipped);
+
         return new NotifyTestResult(testTime, total, sent, skipped, errors);
     }
 
@@ -160,6 +184,10 @@ public class NotificationTestService {
     @Transactional(readOnly = false)
     public NotifyTestResult triggerV1(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
 
+        perfMonitor.reset();
+        long totalStartMs = System.currentTimeMillis();
+
+        long dbReadStart = System.nanoTime();
         List<UserNotificationPreferenceJpaEntity> targets;
 
         // 🎯 특정 유저 리스트가 주어졌다면, 해당 유저들만 대상으로 필터링
@@ -168,14 +196,15 @@ public class NotificationTestService {
         }
         // 🕒 아니면 지정된 시간대(alarmTime) 기준으로 전체 조회
         else {
-//            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
-            targets = prefRepo.findByEnableAlarmsTrue();
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
         }
-
         // ⚙️ limit 지정 시 상한선 적용
         if (limit != null && limit > 0 && targets.size() > limit) {
             targets = targets.subList(0, limit);
         }
+
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
 
         int total = targets.size(); // 조회된 유저 수
         int sent = 0;               // 실제 발송 완료 수
@@ -188,6 +217,9 @@ public class NotificationTestService {
                 Integer userId = user.getUserId();
                 String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
 
+                // Redis GET 구간 측정
+                long rStart = System.nanoTime();
+
                 // Redis에서 세션 상태 확인
                 String status = "NOT_EXIST";
                 Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
@@ -196,6 +228,9 @@ public class NotificationTestService {
                     Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
                     status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
                 }
+
+                long rEnd = System.nanoTime();
+                perfMonitor.addRedisGet(rEnd - rStart);
 
                 // Redis 상태(status)에 따라 알림 메시지 생성
                 NotificationDTO payload = notificationMessageFactory.createNotification(status);
@@ -206,10 +241,9 @@ public class NotificationTestService {
                     continue;
                 }
 
-                // 실제 알림 저장 및 전송
-//                notificationService.sendAndSaveWithNewTransaction(user, payload);
-                notificationService.sendAndSave(user, payload);
-                sent++; //
+                // --- REQUIRES_NEW 트랜잭션(저장 + 커밋 + afterCommit publish) 전체 시간 ---
+                notificationService.sendAndSaveWithNewTransaction(user, payload);
+                sent++;
 
             } catch (Exception e) {
                 // 예외 발생 시 개별 유저 단위로만 로깅 및 계속 진행
@@ -217,6 +251,12 @@ public class NotificationTestService {
                 log.error("error: {}",e.getMessage());
             }
         }
+
+
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V1", totalMs, total, sent, skipped);
 
         // 🧾 실행 결과 요약 반환
         return new NotifyTestResult(testTime, total, sent, skipped, errors);

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -1,0 +1,121 @@
+package com.voiceprint.notification.application.service;
+
+import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
+import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceJpaEntity;
+import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 테스트용 알림 발송 서비스
+ *
+ * 특정 시간대(LocalTime)에 알림을 수동으로 생성·발송하기 위한 유틸성 서비스 클래스.
+ * 운영 스케줄러(DiaryReminderScheduler 등)와 동일한 로직을 사용하지만,
+ * 수동으로 특정 시간대나 특정 유저만 대상으로 테스트할 수 있도록 분리함.
+ */
+@Service
+@RequiredArgsConstructor
+public class NotificationTestService {
+
+    private final UserNotificationPreferenceRepository prefRepo;
+    private final NotificationService notificationService;                // 실제 알림 저장 및 전송 처리
+    private final NotificationMessageFactory notificationMessageFactory;  // status 기반 알림 메시지 생성
+    private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
+
+    private static final String SESSION_KEY_PREFIX = "session";
+
+    /**
+     * 테스트 트리거 메서드
+     *
+     * 주어진 시간대(testTime)에 알림을 발송할 유저를 DB에서 조회한 뒤,
+     * 각 유저의 Redis 상태를 확인하고 알림을 생성(sendAndSave)한다.
+     *
+     * @param testTime     테스트할 알람 시각 (예: 06:30)
+     * @param limit        최대 발송 대상 수 (optional)
+     * @param onlyUserIds  특정 유저 ID 목록 (optional)
+     * @return NotifyTestResult (테스트 결과 요약)
+     */
+    @Transactional(readOnly = false)
+    public NotifyTestResult trigger(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        List<UserNotificationPreferenceJpaEntity> targets;
+
+        // 🎯 특정 유저 리스트가 주어졌다면, 해당 유저들만 대상으로 필터링
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        }
+        // 🕒 아니면 지정된 시간대(alarmTime) 기준으로 전체 조회
+        else {
+//            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+            targets = prefRepo.findByEnableAlarmsTrue();
+        }
+
+        // ⚙️ limit 지정 시 상한선 적용
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+
+        int total = targets.size(); // 조회된 유저 수
+        int sent = 0;               // 실제 발송 완료 수
+        int skipped = 0;            // payload 생성 실패 등으로 건너뛴 수
+        List<String> errors = new ArrayList<>(); // 개별 예외 로그 수집
+
+        // 📦 각 유저별 알림 처리
+        for (UserNotificationPreferenceJpaEntity user : targets) {
+            try {
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                // Redis에서 세션 상태 확인
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+
+                // Redis 상태(status)에 따라 알림 메시지 생성
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+
+                // payload 생성 실패 시 스킵
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // 실제 알림 저장 및 전송
+                notificationService.sendAndSaveWithNewTransaction(user, payload);
+                sent++; //
+
+            } catch (Exception e) {
+                // 예외 발생 시 개별 유저 단위로만 로깅 및 계속 진행
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        // 🧾 실행 결과 요약 반환
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
+
+    /**
+     * 📊 테스트 결과 요약 DTO
+     * - 요청 시각
+     * - 전체 후보 수
+     * - 성공/스킵 수
+     * - 에러 목록
+     */
+    public record NotifyTestResult(
+            LocalTime requestedTime,
+            int totalCandidates,
+            int sent,
+            int skipped,
+            List<String> errors
+    ) {}
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -65,15 +65,30 @@ public class NotificationTestService {
             List<UserNotificationPreferenceJpaEntity> batch = targets.subList(i, end);
 
             try {
+                long batchStart = System.currentTimeMillis();
+
                 BatchResult r = notificationService.processBatchWithNewTransaction(batch);
                 sent += r.getSent();
                 skipped += r.getSkipped();
                 errors.addAll(r.getErrors());
+
+                long batchEnd = System.currentTimeMillis();
+                log.info("[BATCH][V3] size={} took={}ms, sent={}, skipped={}",
+                        batch.size(), (batchEnd - batchStart), r.getSent(), r.getSkipped());
+                if (end < targets.size()) {
+                    try {
+                        Thread.sleep(300L); // Todo : TEST용
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        log.warn("Batch pause interrupted", e);
+                    }
+                }
             } catch (Exception e) {
                 // 이 배치(1000개) 전체가 롤백된 경우
                 errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());
                 log.error("Error processing batch {}-{}", i, end - 1, e);
             }
+
         }
 
         // 마지막 잔여분 처리

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -262,6 +262,108 @@ public class NotificationTestService {
         return new NotifyTestResult(testTime, total, sent, skipped, errors);
     }
 
+    @Transactional(readOnly = false)
+    public NotifyTestResult triggerV4(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        perfMonitor.reset();
+        long totalStartMs = System.currentTimeMillis();
+
+        long dbReadStart = System.nanoTime();
+        List<UserNotificationPreferenceJpaEntity> targets;
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        } else {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+        }
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
+
+        int total = targets.size();
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        // === 1000개씩 끊어서 Batch 처리 ===
+        for (int i = 0; i < targets.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, targets.size());
+            List<UserNotificationPreferenceJpaEntity> batch = targets.subList(i, end);
+
+            try {
+                BatchResult r = notificationService.processBatchRedisOnly(batch);
+                sent += r.getSent();
+                skipped += r.getSkipped();
+                errors.addAll(r.getErrors());
+            } catch (Exception e) {
+                // 이 배치(1000개) 전체가 롤백된 경우
+                errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());
+                log.error("Error processing batch {}-{}", i, end - 1, e);
+            }
+        }
+
+        // 마지막 잔여분 처리
+        notificationService.flushAndClear();
+
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V3", totalMs, total, sent, skipped);
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
+
+    @Transactional(readOnly = false)
+    public NotifyTestResult triggerV5(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        perfMonitor.reset();
+        long totalStartMs = System.currentTimeMillis();
+
+        long dbReadStart = System.nanoTime();
+        List<UserNotificationPreferenceJpaEntity> targets;
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        } else {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+        }
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
+
+        int total = targets.size();
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        // === 1000개씩 끊어서 Batch 처리 ===
+        for (int i = 0; i < targets.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, targets.size());
+            List<UserNotificationPreferenceJpaEntity> batch = targets.subList(i, end);
+
+            try {
+                BatchResult r = notificationService.processBatchRedisAndDbNoPublish(batch);
+                sent += r.getSent();
+                skipped += r.getSkipped();
+                errors.addAll(r.getErrors());
+            } catch (Exception e) {
+                // 이 배치(1000개) 전체가 롤백된 경우
+                errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());
+                log.error("Error processing batch {}-{}", i, end - 1, e);
+            }
+        }
+
+        // 마지막 잔여분 처리
+        notificationService.flushAndClear();
+
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V3", totalMs, total, sent, skipped);
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
+
     /**
      * 📊 테스트 결과 요약 DTO
      * - 요청 시각

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -3,7 +3,9 @@ package com.voiceprint.notification.application.service;
 import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
 import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceJpaEntity;
 import com.voiceprint.notification.adapter.out.persistence.UserNotificationPreferenceRepository;
+import com.voiceprint.notification.dto.BatchResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import java.util.List;
  * 수동으로 특정 시간대나 특정 유저만 대상으로 테스트할 수 있도록 분리함.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class NotificationTestService {
 
@@ -29,6 +32,119 @@ public class NotificationTestService {
     private final RedisTemplate<String, Object> redisTemplate;            // Redis 상태 조회용 (세션 상태 등)
 
     private static final String SESSION_KEY_PREFIX = "session";
+    private static final int BATCH_SIZE = 1000;
+
+    @Transactional(readOnly = false)
+    public NotifyTestResult triggerV3(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        List<UserNotificationPreferenceJpaEntity> targets;
+
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        } else {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+        }
+
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+
+        int total = targets.size();
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        // === 1000개씩 끊어서 Batch 처리 ===
+        for (int i = 0; i < targets.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, targets.size());
+            List<UserNotificationPreferenceJpaEntity> batch = targets.subList(i, end);
+
+            try {
+                BatchResult r = notificationService.processBatchWithNewTransaction(batch);
+                sent += r.getSent();
+                skipped += r.getSkipped();
+                errors.addAll(r.getErrors());
+            } catch (Exception e) {
+                // 이 배치(1000개) 전체가 롤백된 경우
+                errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());
+                log.error("Error processing batch {}-{}", i, end - 1, e);
+            }
+        }
+
+        // 마지막 잔여분 처리
+        notificationService.flushAndClear();
+
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
+    /**
+     * v2 – JPA Batch 기반 처리 버전
+     *
+     * - sendAndSaveWithJpaBatch() 에서 em.persist() + afterCommit 등록만 수행
+     * - 여기서 BATCH_SIZE마다 flushAndClear() 호출
+     */
+    @Transactional(readOnly = false)
+    public NotifyTestResult triggerV2(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        List<UserNotificationPreferenceJpaEntity> targets;
+
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        } else {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+        }
+
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+
+        int total = targets.size();
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        int processed = 0;
+
+        for (UserNotificationPreferenceJpaEntity user : targets) {
+            try {
+                Integer userId = user.getUserId();
+                String sessionKey = SESSION_KEY_PREFIX + ":" + userId;
+
+                String status = "NOT_EXIST";
+                Boolean hasStatus = redisTemplate.opsForHash().hasKey(sessionKey, "status");
+
+                if (Boolean.TRUE.equals(hasStatus)) {
+                    Object statusObj = redisTemplate.opsForHash().get(sessionKey, "status");
+                    status = statusObj != null ? statusObj.toString().replace("\"", "") : "NOT_EXIST";
+                }
+
+                NotificationDTO payload = notificationMessageFactory.createNotification(status);
+
+                if (payload == null) {
+                    skipped++;
+                    continue;
+                }
+
+                // JPA Batch 버전: persist만 쌓아두고, afterCommit에서 Redis 발행
+                notificationService.sendAndSaveWithBatch(user, payload);
+                sent++;
+                processed++;
+
+                // 배치 경계마다 flush + clear
+                if (processed % BATCH_SIZE == 0) {
+                    notificationService.flushAndClear();
+                }
+
+            } catch (Exception e) {
+                log.error("Error processing user {} during notification test", user.getUserId(), e);
+                errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+            }
+        }
+
+        // 마지막 잔여분 처리
+        notificationService.flushAndClear();
+
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
 
     /**
      * 테스트 트리거 메서드
@@ -42,7 +158,7 @@ public class NotificationTestService {
      * @return NotifyTestResult (테스트 결과 요약)
      */
     @Transactional(readOnly = false)
-    public NotifyTestResult trigger(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+    public NotifyTestResult triggerV1(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
 
         List<UserNotificationPreferenceJpaEntity> targets;
 
@@ -91,12 +207,14 @@ public class NotificationTestService {
                 }
 
                 // 실제 알림 저장 및 전송
-                notificationService.sendAndSaveWithNewTransaction(user, payload);
+//                notificationService.sendAndSaveWithNewTransaction(user, payload);
+                notificationService.sendAndSave(user, payload);
                 sent++; //
 
             } catch (Exception e) {
                 // 예외 발생 시 개별 유저 단위로만 로깅 및 계속 진행
                 errors.add("userId=" + user.getUserId() + ", err=" + e.getMessage());
+                log.error("error: {}",e.getMessage());
             }
         }
 

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -77,14 +77,6 @@ public class NotificationTestService {
                 long batchEnd = System.currentTimeMillis();
                 log.info("[BATCH][V6-JDBC] size={} took={}ms, sent={}, skipped={}",
                         batch.size(), (batchEnd - batchStart), r.getSent(), r.getSkipped());
-                if (end < targets.size()) {
-                    try {
-                        Thread.sleep(300L); // Todo : TEST용
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        log.warn("Batch pause interrupted", e);
-                    }
-                }
             } catch (Exception e) {
                 // 이 배치(1000개) 전체가 롤백된 경우
                 errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationTestService.java
@@ -36,6 +36,71 @@ public class NotificationTestService {
     private static final int BATCH_SIZE = 1000;
 
     @Transactional(readOnly = false)
+    public NotifyTestResult triggerV6(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
+
+        perfMonitor.reset();
+        long totalStartMs = System.currentTimeMillis();
+
+        long dbReadStart = System.nanoTime();
+        List<UserNotificationPreferenceJpaEntity> targets;
+        if (onlyUserIds != null && !onlyUserIds.isEmpty()) {
+            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTimeAndUserIdIn(testTime, onlyUserIds);
+        } else {
+//            targets = prefRepo.findByEnableAlarmsTrueAndAlarmTime(testTime);
+            targets = prefRepo.findByEnableAlarmsTrue();
+        }
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+        long dbReadEnd = System.nanoTime();
+        perfMonitor.addDbRead(dbReadEnd - dbReadStart);
+
+        int total = targets.size();
+        int sent = 0;
+        int skipped = 0;
+        List<String> errors = new ArrayList<>();
+
+        // === 1000개씩 끊어서 Batch 처리 ===
+        for (int i = 0; i < targets.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, targets.size());
+            List<UserNotificationPreferenceJpaEntity> batch = targets.subList(i, end);
+
+            try {
+                long batchStart = System.currentTimeMillis();
+
+                // JDBC 버전 호출
+                BatchResult r = notificationService.processBatchWithJdbc(batch);
+                sent += r.getSent();
+                skipped += r.getSkipped();
+                errors.addAll(r.getErrors());
+
+                long batchEnd = System.currentTimeMillis();
+                log.info("[BATCH][V6-JDBC] size={} took={}ms, sent={}, skipped={}",
+                        batch.size(), (batchEnd - batchStart), r.getSent(), r.getSkipped());
+                if (end < targets.size()) {
+                    try {
+                        Thread.sleep(300L); // Todo : TEST용
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        log.warn("Batch pause interrupted", e);
+                    }
+                }
+            } catch (Exception e) {
+                // 이 배치(1000개) 전체가 롤백된 경우
+                errors.add("batch[" + i + "~" + (end - 1) + "] failed : " + e.getMessage());
+                log.error("Error processing batch {}-{}", i, end - 1, e);
+            }
+
+        }
+
+        long totalEndMs = System.currentTimeMillis();
+        long totalMs = totalEndMs - totalStartMs;
+
+        perfMonitor.logSummary("V6", totalMs, total, sent, skipped);
+        return new NotifyTestResult(testTime, total, sent, skipped, errors);
+    }
+
+    @Transactional(readOnly = false)
     public NotifyTestResult triggerV3(LocalTime testTime, Integer limit, List<Integer> onlyUserIds) {
 
         perfMonitor.reset();
@@ -378,6 +443,8 @@ public class NotificationTestService {
         perfMonitor.logSummary("V3", totalMs, total, sent, skipped);
         return new NotifyTestResult(testTime, total, sent, skipped, errors);
     }
+
+
 
     /**
      * 📊 테스트 결과 요약 DTO

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/ReminderNotificationMessageFactory.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/ReminderNotificationMessageFactory.java
@@ -1,0 +1,35 @@
+package com.voiceprint.notification.application.service;
+
+import com.voiceprint.notification.adapter.in.web.dto.NotificationDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component("reminderNotificationMessageFactory")
+public class ReminderNotificationMessageFactory implements NotificationMessageFactory {
+
+    @Override
+    public NotificationDTO createNotification(String status) {
+        return switch (status) {
+            case "WAITING", "NOT_EXIST" -> new NotificationDTO(
+                    "reminder",
+                    "오늘은 일기 쓰셨나요? 말자국으로 오늘 하루를 기록해 보세요!!",
+                    Map.of("status", status)
+            );
+            case "IN_PROGRESS" -> new NotificationDTO(
+                    "reminder",
+                    "대화가 아직 진행중이에요. 대화를 완료하고 일기를 생성해주세요!",
+                    Map.of("status", status)
+            );
+            case "DIARY_DONE", "DIARY_CREATING" -> new NotificationDTO(
+                    "reminder", "생성된 일기가 있어요. 저장을 잊지 마세요!",
+                    Map.of("status", status)
+            );
+            case "ERROR" -> new NotificationDTO(
+                    "reminder", "일기 저장 중 오류가 발생했어요!",
+                    Map.of("status", status)
+            );
+            default -> null; // DIARY_SAVED 알림 없음
+        };
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/dto/BatchResult.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/dto/BatchResult.java
@@ -1,0 +1,14 @@
+package com.voiceprint.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BatchResult {
+    private final int sent;
+    private final int skipped;
+    private final List<String> errors;
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.voiceprint.notification.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    // Async("notifi...") 형태로 연결
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);        // 기본 스레드
+        executor.setMaxPoolSize(8);         // 최대 스레드
+        executor.setQueueCapacity(10_000);  // 실행 대기 중인 큐 용량
+        executor.setThreadNamePrefix("notification-async-"); // 디버깅 로그
+        executor.initialize();
+        return executor;
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
@@ -15,8 +15,8 @@ public class AsyncConfig {
     @Bean(name = "notificationExecutor")
     public Executor notificationExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(4);        // 기본 스레드
-        executor.setMaxPoolSize(8);         // 최대 스레드
+        executor.setCorePoolSize(40);        // 기본 스레드
+        executor.setMaxPoolSize(50);         // 최대 스레드
         executor.setQueueCapacity(10_000);  // 실행 대기 중인 큐 용량
         executor.setThreadNamePrefix("notification-async-"); // 디버깅 로그
         executor.initialize();

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/PubSubRedisConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/PubSubRedisConfig.java
@@ -1,0 +1,78 @@
+package com.voiceprint.notification.global.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@Configuration
+public class PubSubRedisConfig {
+
+    @Value("${notification.redis.pubsub.host}")
+    private String pubsubHost;
+
+    @Value("${notification.redis.pubsub.port}")
+    private Integer pubsubPort;
+
+    @Value("${notification.redis.pubsub.password}")
+    private String pubsubPassword;
+
+    @PostConstruct
+    public void printPubSubRedisHost() {
+        log.debug("[PUBSUB REDIS] 연결 호스트: {}", pubsubHost);
+    }
+
+    @Bean
+    public RedisConnectionFactory pubsubRedisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(pubsubHost);
+        config.setPort(pubsubPort);
+        config.setPassword(pubsubPassword);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder().build();
+        return new LettuceConnectionFactory(config, clientConfig);
+    }
+
+    @Bean(name = "pubsubRedisTemplate")
+    public RedisTemplate<String, Object> pubsubRedisTemplate(
+            @Qualifier("pubsubRedisConnectionFactory")
+            RedisConnectionFactory connectionFactory
+    ) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    /**
+     * pub/sub 전용 ListenerContainer
+     * -> 이 컨테이너는 pubsub Redis 인스턴스에만 붙음
+     */
+    @Bean
+    public RedisMessageListenerContainer pubsubRedisContainer(
+            @Qualifier("pubsubRedisConnectionFactory")
+            RedisConnectionFactory factory,
+            MessageListenerAdapter adapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(factory);
+        container.addMessageListener(adapter, new PatternTopic("notification-channel"));
+        return container;
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/RedisConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/RedisConfig.java
@@ -6,13 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -29,42 +28,39 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String redisPassword;
 
-//    @Value("${spring.data.redis.ssl.enabled}")
-//    private boolean sslEnabled;
-
     @PostConstruct
     public void printRedisHost() {
-        log.debug("🔍 Redis 연결 호스트: " + redisHost);
+        log.debug("🔍 [SESSION REDIS] 연결 호스트: " + redisHost);
     }
 
-
+    /**
+     * 세션/H_GET 전용 Redis (spring.data.redis 기준)
+     */
     @Bean
-    public RedisConnectionFactory redisConnectFactory() {
-        // Lettuce 기반 커넥션 팩토리
-        // RedisPool 관리.
-
+    @Primary
+    public RedisConnectionFactory sessionRedisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(redisHost);
         config.setPort(redisPort);
         config.setPassword(redisPassword);
 
         LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-//                .useSsl() // Upstash Redis는 SSL 사용
                 .build();
         return new LettuceConnectionFactory(config, clientConfig);
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    @Primary
+    public RedisTemplate<String, Object> sessionRedisTemplate(
+            RedisConnectionFactory sessionRedisConnectionFactory
+    ) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
+        template.setConnectionFactory(sessionRedisConnectionFactory);
 
         // [Key] 문자열로 처리
         template.setKeySerializer(new StringRedisSerializer());
-
         // [Value] JSON 형태로 객체 저장(직렬화)
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
         // [Hash Key/Value]도 동일하게 설정
         template.setHashKeySerializer(new StringRedisSerializer());
         template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
@@ -83,23 +79,4 @@ public class RedisConfig {
     public MessageListenerAdapter messageListenerAdapter(RedisSubscriber subscriber) {
         return new MessageListenerAdapter(subscriber);
     }
-
-    /**
-     * Redis Pub/Sub 채널을 지속적으로 구독하는 리스터 루프 역할.
-     * "notifiaction-channel"
-     * 메시지를 받으면, 등록된 MessageListenerAdapter로 전달
-     *
-     * redis의 특정 채널을 지속적으로 구독하며, MessageListenerAdapter로 연결하여
-     * 비동기 스레드 풀로 동작함.
-     */
-    @Bean
-    public RedisMessageListenerContainer redisContainer(
-            RedisConnectionFactory factory, MessageListenerAdapter adapter) {
-        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-        container.setConnectionFactory(factory);
-        container.addMessageListener(adapter, new PatternTopic("notification-channel"));
-        return container;
-    }
-
-
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/SchedulerConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package com.voiceprint.notification.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig implements SchedulingConfigurer {
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(3); // 동시에 3개 작업 처리
+        scheduler.setThreadNamePrefix("scheduler-");  // 로그 추적용 접두사
+        scheduler.initialize();
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/SchedulerConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/SchedulerConfig.java
@@ -6,14 +6,23 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+/**
+ * SchedulerConfig
+ *
+ * 스프링의 기본 스케줄러 설정을 커스터마이징하기 위한 구성 클래스.
+ * 기본적으로 Spring Scheduler는 단일 스레드에서 모든 @Scheduled 작업을 순차적으로 실행한다.
+ *
+ * 아래 설정을 통해 ThreadPoolTaskScheduler를 직접 구성하여,
+ * 여러 @Scheduled 작업이 동시에 실행될 수 있도록 스레드풀 기반으로 확장한다.
+ */
 @Configuration
 @EnableScheduling
 public class SchedulerConfig implements SchedulingConfigurer {
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(3); // 동시에 3개 작업 처리
-        scheduler.setThreadNamePrefix("scheduler-");  // 로그 추적용 접두사
+        scheduler.setPoolSize(3);                       // 동시에 3개 작업 처리
+        scheduler.setThreadNamePrefix("scheduler-");    // 로그 추적용 접두사
         scheduler.initialize();
         taskRegistrar.setTaskScheduler(scheduler);
     }


### PR DESCRIPTION
# 🚀 perf: reminder-notification optimization

## 💡 개요
기존 단일 Redis 인스턴스 + 단일 트랜잭션 구조에서  
`HGET`(세션 조회), `INSERT`, `PUBLISH`가 모두 한 흐름에서 직렬적으로 수행되며,  
Redis 싱글스레드 특성 및 커넥션 병목으로 인해 전체 처리 지연이 발생했습니다.

이번 MR에서는 Redis 인스턴스 분리, 트랜잭션 경계 재설계,  
비동기 처리 및 JDBC Batch + Redis Pipeline을 도입하여  
Notification 파이프라인 전체를 재구성했습니다.

---

## 🔧 주요 변경사항

### 🧱 1. 트랜잭션 구조 개선
- `@Transactional(propagation = REQUIRES_NEW)` 도입  
  → 배치 단위(1000건)마다 **독립 트랜잭션 커밋**  
  → 실패 구간만 재처리 가능하도록 범위 축소  
- `TransactionSynchronization.afterCommit()` 내부에 비동기 publish 등록  
  → 메인 트랜잭션과 Redis Publish 완전 분리

---

### ⚙️ 2. 비동기 처리 구조 확립
- `AsyncNotificationPublisher` 추가  
  → afterCommit 이후 비동기로 Redis Publish 수행  
- `AsyncConfig` 스레드 풀 확장  
  - `corePoolSize` 4 → 50
  - `queueCapacity` (10,000) 증가  
  → 대량 Publish 시 대기 없이 병렬 분산

---

### 🧵 3. JDBC Batch Insert 도입
- 기존 JPA 단건 insert → **JDBC batch insert** 전환  
    - JPA & IDENTITY 전략 충돌
- `rewriteBatchedStatements=true` 설정 및 `batch_size=1000`  
- insert 성능 약 **600초 → 8초 (50만건 기준)** 으로 단축

---

### 🔄 4. Redis Pipeline 도입
- `SessionStatusReader.getStatusesWithPipeline()`  
  → `HGET` 명령을 파이프라인으로 묶어 RTT 최소화  
- `RedisPublisher.publishAllPipeline()`  
  → `PUBLISH` 명령도 파이프라인 처리로 전송량 집약화  
- publish latency 3~4초 → **6~9ms 수준**으로 안정화

---

### 📡 5. Redis 인스턴스 이중화
- 기존 `spring.data.redis` → 세션/HGET 전용  
- 신규 `notification.redis.pubsub` → PUBLISH / SUBSCRIBE 전용  
- `docker-compose.yml` 에 `redis-pubsub` 추가  
- `@Primary` 및 `@Qualifier("pubsubRedisTemplate")` 기반 명시적 분리

---

### ⚙️ 6. Redis / Async Pool 확장
- Lettuce pool  
  - `max-active`: 8 → "50"
  - `min-idle`: 10  
  - `max-wait`: 3000ms  
- Async Executor  
  - 병렬 publish 시 스레드 및 커넥션 대기 병목 제거  

---

## 📈 성능 개선 요약 (500k 사용자 기준)

| 구분 | 개선 전 | 개선 후 | 변화율 |
|------|---------------|---------------|---------|
| 전체 처리시간 | 220s | **18s** | 🔽 -99% |
| Redis HGET | 40s | **4s** | 🔽 -90% |
| Redis Publish | null | **batch(1000EA)/(5~10)s** | ✅ |
| DB Insert | 600s | **9s** | ↔ 유지 |
| Async Delay | 주기적 스파이크 | **0.0s 안정화** | ✅ |

---

## 🧩 아키텍처 (Before → After)
```
Before
┌──────────────────────────────────────────────┐
│ 단일 Redis + 단일 트랜잭션 구조             │
│ ├─ @Transactional                           │
│ │  ├─ HGET (Redis)                          │
│ │  ├─ INSERT (JPA)                          │
│ │  └─ PUBLISH (Redis)                       │
│ └─ 모든 단계 직렬 실행                      │
└──────────────────────────────────────────────┘

After
┌──────────────────────────────────────────────┐
│ Redis & 트랜잭션 분리 구조 (V6)              │
│ ├─ REQUIRES_NEW (1000건 단위 커밋)           │
│ ├─ afterCommit() → AsyncPublisher 비동기 처리 │
│ ├─ JDBC Batch Insert                         │
│ ├─ HGET Pipeline (세션 Redis)                │
│ └─ PUBLISH Pipeline (Pub/Sub Redis)          │
└──────────────────────────────────────────────┘
```
