### PR TITLE
feat: Distributed Tracing & MDC Logging System

### DIFF
--- a/config-repo/backend-msa.yml
+++ b/config-repo/backend-msa.yml
@@ -13,11 +13,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     open-in-view: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         jdbc:
           time_zone: Asia/Seoul
 

--- a/config-repo/notification-service.yml
+++ b/config-repo/notification-service.yml
@@ -28,10 +28,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
       # JPA batch.
       jdbc:
         batch_size: 1000           # 한 번에 전송할 레코드 수

--- a/services/backend-msa/src/main/java/com/voiceprint/backend/global/filter/MdcFilter.java
+++ b/services/backend-msa/src/main/java/com/voiceprint/backend/global/filter/MdcFilter.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 public class MdcFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID = "traceId";
+    private static final String TRACE_HEADER = "X-Trace-Id";
 
     /**
      * 실제 필터 로직.
@@ -28,12 +29,23 @@ public class MdcFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String traceId = MDC.get(TRACE_ID);
-            if (traceId == null) {
-                // UUID에서 앞 8자리 사용. - 만약 header를 통해 traceId가 들어온다면 해당 친구 사용.
-                traceId = UUID.randomUUID().toString().substring(0,8);
-                MDC.put(TRACE_ID, traceId);
+            // 1) 먼저 헤더에서 traceId를 찾는다 (서비스 간 전파용)
+            String traceId = request.getHeader(TRACE_HEADER);
+
+            // 2) 헤더에 없으면 MDC에서 한 번 더 확인 (이미 세팅된 경우)
+            if (traceId == null || traceId.isBlank()) {
+                traceId = MDC.get(TRACE_ID);
             }
+
+            // 3) 그래도 없으면 새로 생성 (이 서비스가 최초 진입점일 수도 있으니까)
+            if (traceId == null || traceId.isBlank()) {
+                traceId = UUID.randomUUID().toString().substring(0, 8);
+            }
+            // 4) put.
+            MDC.put(TRACE_ID, traceId);
+
+            // 응답 헤더에도 넣어줌.
+            response.setHeader(TRACE_HEADER, traceId);
 
             filterChain.doFilter(request, response);
         } finally {

--- a/services/backend-msa/src/main/java/com/voiceprint/backend/global/filter/MdcFilter.java
+++ b/services/backend-msa/src/main/java/com/voiceprint/backend/global/filter/MdcFilter.java
@@ -1,0 +1,46 @@
+package com.voiceprint.backend.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * HTTP 요청마다 traceId를 생성해서 MDC에 넣어주는 필터.
+ * - OncePerRequestFilter 를 상속했기 때문에 한 요청당 한 번만 실행됨.
+ * - 이후 모든 로그에서 %X{traceId} 로 같은 traceId를 확인할 수 있다.
+ */
+@Component
+public class MdcFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+
+    /**
+     * 실제 필터 로직.
+     * 요청이 들어올 때 traceId를 MDC에 넣고,
+     * 체인 이후 finally 에서 MDC를 정리(cleanup) 해준다.
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String traceId = MDC.get(TRACE_ID);
+            if (traceId == null) {
+                // UUID에서 앞 8자리 사용. - 만약 header를 통해 traceId가 들어온다면 해당 친구 사용.
+                traceId = UUID.randomUUID().toString().substring(0,8);
+                MDC.put(TRACE_ID, traceId);
+            }
+
+            filterChain.doFilter(request, response);
+        } finally {
+            // 요청 처리가 끝나면 MDC를 반드시 비워줘야 함.
+            // MDC는 내부적으로 ThreadLocal을 사용하기 때문에,
+            // 스레드풀 환경에서는 이전 요청의 값이 다음 요청에 섞이지 않도록 정리 필수.
+            MDC.clear();
+        }
+    }
+}

--- a/services/backend-msa/src/main/java/com/voiceprint/backend/global/outbox/OutboxEventScheduler.java
+++ b/services/backend-msa/src/main/java/com/voiceprint/backend/global/outbox/OutboxEventScheduler.java
@@ -6,6 +6,7 @@ import com.voiceprint.backend.global.event.UserEvent;
 import com.voiceprint.backend.user.application.port.out.UserEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Outbox 테이블을 주기적으로 폴링하여 저장된 이벤트를 실제 메시지 브로커로 발행하는 스케줄러
@@ -40,8 +42,14 @@ public class OutboxEventScheduler {
         List<OutboxEventJpaEntity> events = outboxEventRepository
             .findByStatusOrderByOccurredAtAsc(OutboxEventJpaEntity.EventStatus.PENDING, PageRequest.of(0, 100));
 
+
         for (OutboxEventJpaEntity event : events) {
+            // 이벤트 하나 처리 단위로 traceId 생성
+            String traceId = UUID.randomUUID().toString().substring(0, 8);
+
             try {
+                MDC.put("traceId",traceId);
+
                 // 발행 시도 횟수 증가 -
                 event.incrementAttempts();
 
@@ -85,6 +93,8 @@ public class OutboxEventScheduler {
                     event.markAsFailed();
                     log.warn("Event id: {} has failed {} times and will be marked as FAILED.", event.getId(), event.getAttempts());
                 }
+            } finally {
+                MDC.clear(); // clear
             }
         }
     }

--- a/services/backend-msa/src/main/java/com/voiceprint/backend/user/adapter/out/messaging/UserEventKafkaAdapter.java
+++ b/services/backend-msa/src/main/java/com/voiceprint/backend/user/adapter/out/messaging/UserEventKafkaAdapter.java
@@ -5,7 +5,11 @@ import com.voiceprint.backend.global.event.UserEvent;
 import com.voiceprint.backend.user.application.port.out.UserEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -36,8 +40,19 @@ public class UserEventKafkaAdapter implements UserEventPort {
     private void send(UserEvent event, String key) {
         try {
             String jsonMessage = objectMapper.writeValueAsString(event);
-            log.info("Sending message to topic '{}' with key: {}", TOPIC, key);
-            kafkaTemplate.send(TOPIC, key, jsonMessage);
+            String traceId = MDC.get("traceId"); // 스케줄러에서 세팅해둔 값
+
+            log.info("Sending message to topic='{}' key={} userId={} traceId={}",
+                    TOPIC, key, event.getUserId(), traceId);
+
+            Message<String> message = MessageBuilder
+                    .withPayload(jsonMessage)
+                    .setHeader(KafkaHeaders.TOPIC, TOPIC)
+                    .setHeader(KafkaHeaders.KEY, key)
+                    .setHeader("X-Trace-Id", traceId) // ★ traceId를 헤더로 전달
+                    .build();
+
+            kafkaTemplate.send(message);
         } catch (Exception e) {
             log.error("Failed to send message to kafka topic '{}'", TOPIC, e);
         }

--- a/services/backend-msa/src/main/resources/logback-spring.xml
+++ b/services/backend-msa/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{traceId:-}] %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/services/gateway-service/src/main/java/com/voiceprint/gateway/logger/GlobalLoggerFilter.java
+++ b/services/gateway-service/src/main/java/com/voiceprint/gateway/logger/GlobalLoggerFilter.java
@@ -2,6 +2,7 @@ package com.voiceprint.gateway.logger;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -9,28 +10,68 @@ import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.util.UUID;
+
 @Component
 @Slf4j
 public class GlobalLoggerFilter extends AbstractGatewayFilterFactory<GlobalLoggerFilter.Config> {
-    public GlobalLoggerFilter() { super(Config.class); }
+
+    private static final String TRACE_HEADER = "X-Trace-Id";
+
+    public GlobalLoggerFilter() {
+        super(Config.class);
+    }
 
     @Override
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
-            ServerHttpRequest request = exchange.getRequest();
-            ServerHttpResponse response = exchange.getResponse();
+            ServerHttpRequest originalRequest = exchange.getRequest();
 
-            log.info("Global Filter baseMessage: {}, {}", config.getBaseMessage(), request.getRemoteAddress());
+            // 1) 들어온 요청의 X-Trace-Id 헤더를 확인
+            String traceId = originalRequest.getHeaders().getFirst(TRACE_HEADER);
 
-            if (config.isPreLogger()) {
-                log.info("Global Filter Start: request id -> {}", request.getId());
+            // 2) 클라이언트가 보내지 않았다면 Gateway가 새로 생성
+            if (traceId == null || traceId.isBlank()) {
+                traceId = UUID.randomUUID().toString().substring(0, 8);
             }
 
-            return chain.filter(exchange).then(Mono.fromRunnable(() -> {
-                if (config.isPostLogger()) {
-                    log.info("Global Filter End: response code -> {}", response.getStatusCode());
+            // 3) downstream 으로 넘길 요청에 X-Trace-Id 를 항상 세팅
+            ServerHttpRequest mutatedRequest = originalRequest.mutate()
+                    .header(TRACE_HEADER, traceId)
+                    .build();
+
+            // 4) 교체한 request 로 exchange 재구성
+            var mutatedExchange = exchange.mutate()
+                    .request(mutatedRequest)
+                    .build();
+
+            // ---- Request 로그 ----
+            if (config.isPreLogger()) {
+                try {
+                    MDC.put("traceId", traceId);
+                    log.info("Gateway Request: method={}, path={}, remote={}",
+                            mutatedRequest.getMethod(),
+                            mutatedRequest.getURI().getPath(),
+                            mutatedRequest.getRemoteAddress());
+                } finally {
+                    MDC.clear();
                 }
-            }));
+            }
+
+            String finalTraceId = traceId;
+            // ---- Filter 체인 + Response 로그 ----
+            return chain.filter(mutatedExchange)
+                    .then(Mono.fromRunnable(() -> {
+                        if (config.isPostLogger()) {
+                            ServerHttpResponse response = mutatedExchange.getResponse();
+                            try {
+                                MDC.put("traceId", finalTraceId);
+                                log.info("Gateway Response: status={}", response.getStatusCode());
+                            } finally {
+                                MDC.clear();
+                            }
+                        }
+                    }));
         };
     }
 
@@ -39,6 +80,5 @@ public class GlobalLoggerFilter extends AbstractGatewayFilterFactory<GlobalLogge
         private String baseMessage;
         private boolean preLogger;
         private boolean postLogger;
-
     }
 }

--- a/services/gateway-service/src/main/resources/logback-spring.xml
+++ b/services/gateway-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{traceId:-}] %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/kafka/NotificationConsumer.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/kafka/NotificationConsumer.java
@@ -6,6 +6,7 @@ import com.voiceprint.notification.adapter.out.persistence.ProcessedEventJPARepo
 import com.voiceprint.notification.application.port.in.NotificationEventHandlerPort;
 import java.time.LocalTime;
 import java.util.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,8 +52,67 @@ public class NotificationConsumer {
     /**
      * 유저 생성 및 데이터 변경에 대한 이벤트를 수신하는 Listener
      */
+
     @KafkaListener(topics = "user-events", groupId = "voiceprint-notification")
-    public void consumeUserEvents(String message) {
+    public void consumeUserEvents(ConsumerRecord<String, String> record) {
+        String message = record.value();
+        try {
+            Map<String, Object> eventMap = objectMapper.readValue(
+                    message,
+                    new TypeReference<Map<String, Object>>() {}
+            );
+
+            String eventType = (String) eventMap.get("eventType");
+            Integer userId = (Integer) eventMap.get("userId");
+
+            String eventId = (String) eventMap.get("eventId");
+            if (eventId == null || eventId.isBlank()) {
+                throw new IllegalArgumentException("missing eventId");
+            }
+
+            if (processedEventRepository.existsById(eventId)) {
+                log.debug("이미 처리된 user-event: {}", eventId);
+                return;
+            }
+
+            switch (eventType) {
+                // 유저 등록
+                case "USER_REGISTERED":
+                    String nickname = (String) eventMap.get("nickname");
+                    String email = (String) eventMap.get("email");
+                    notificationEventHandlerPort.handleUserRegisteredEvent(userId, nickname, email);
+                    break;
+                // 유저 프로필 업데이트
+                case "USER_PROFILE_UPDATED":
+                    String updatedNickname = (String) eventMap.get("nickname");
+                    String updatedEmail = (String) eventMap.get("email");
+                    notificationEventHandlerPort.handleUserProfileUpdatedEvent(userId, updatedNickname, updatedEmail);
+                    break;
+                // 유저 알람 정보 갱신
+                case "USER_NOTIFICATION_PREFERENCES_UPDATED":
+                    Boolean enableAlarms = (Boolean) eventMap.get("enableAlarms");
+                    String alarmTimeString = (String) eventMap.get("alarmTime");
+                    LocalTime alarmTime = null;
+                    if (alarmTimeString != null) {
+                        alarmTime = LocalTime.parse(alarmTimeString);
+                    }
+                    notificationEventHandlerPort.handleUserNotificationPreferencesUpdatedEvent(userId, enableAlarms, alarmTime);
+                    break;
+                default:
+                    log.warn("Unknown user event type: {}", eventType);
+                    break;
+            }
+            log.info("Successfully processed user event: {}", eventType);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize user event message: {}", message, e);
+        } catch (Exception e) {
+            log.error("Failed to process user event: {}", message, e);
+        }
+    }
+
+    @Deprecated
+//    @KafkaListener(topics = "user-events", groupId = "voiceprint-notification")
+    public void consumeUserEventsD(String message) {
         log.info("Consumed user event message: {}", message);
         try {
             Map<String, Object> eventMap = objectMapper.readValue(message, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});

--- a/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/kafka/NotificationConsumer.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/adapter/in/kafka/NotificationConsumer.java
@@ -11,7 +11,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.MDC;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -54,9 +56,16 @@ public class NotificationConsumer {
      */
 
     @KafkaListener(topics = "user-events", groupId = "voiceprint-notification")
-    public void consumeUserEvents(ConsumerRecord<String, String> record) {
+    public void consumeUserEvents(
+            ConsumerRecord<String, String> record,
+            @Header(name = "X-Trace-Id", required = false) String traceId // ★ 추가
+    ) {
+        // Kafka 메시지 페이로드
         String message = record.value();
+
         try {
+            MDC.put("traceId", traceId);
+
             Map<String, Object> eventMap = objectMapper.readValue(
                     message,
                     new TypeReference<Map<String, Object>>() {}
@@ -74,18 +83,23 @@ public class NotificationConsumer {
                 log.debug("이미 처리된 user-event: {}", eventId);
                 return;
             }
+            log.info("user-event received: eventId={}, userId={}", eventId, userId);
 
             switch (eventType) {
                 // 유저 등록
                 case "USER_REGISTERED":
                     String nickname = (String) eventMap.get("nickname");
                     String email = (String) eventMap.get("email");
+                    log.info("Handling USER_REGISTERED: userId={}, nickname={}, email={}",
+                            userId, nickname, email);
                     notificationEventHandlerPort.handleUserRegisteredEvent(userId, nickname, email);
                     break;
                 // 유저 프로필 업데이트
                 case "USER_PROFILE_UPDATED":
                     String updatedNickname = (String) eventMap.get("nickname");
                     String updatedEmail = (String) eventMap.get("email");
+                    log.info("Handling USER_PROFILE_UPDATED: userId={}, nickname={}, email={}",
+                            userId, updatedNickname, updatedEmail);
                     notificationEventHandlerPort.handleUserProfileUpdatedEvent(userId, updatedNickname, updatedEmail);
                     break;
                 // 유저 알람 정보 갱신
@@ -96,6 +110,8 @@ public class NotificationConsumer {
                     if (alarmTimeString != null) {
                         alarmTime = LocalTime.parse(alarmTimeString);
                     }
+                    log.info("Handling USER_NOTIFICATION_PREFERENCES_UPDATED: userId={}, enableAlarms={}, alarmTime={}",
+                            userId, enableAlarms, alarmTime);
                     notificationEventHandlerPort.handleUserNotificationPreferencesUpdatedEvent(userId, enableAlarms, alarmTime);
                     break;
                 default:
@@ -107,6 +123,8 @@ public class NotificationConsumer {
             log.error("Failed to deserialize user event message: {}", message, e);
         } catch (Exception e) {
             log.error("Failed to process user event: {}", message, e);
+        } finally {
+            MDC.clear();
         }
     }
 

--- a/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationEventService.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/application/service/NotificationEventService.java
@@ -107,6 +107,9 @@ public class NotificationEventService implements NotificationEventHandlerPort {
         if (enableAlarms != null && Boolean.TRUE.equals(enableAlarms) && alarmTime == null) {
             throw new IllegalArgumentException("alarmTime is required when enableAlarms=true");
         }
+
+        log.info("Handling notification preference update: userId={}, enableAlarms={}, alarmTime={}",
+                userId, enableAlarms, alarmTime);
         // 2) 조회 & 사용자 알림 설정 업데이트
         UserNotificationPreferenceJpaEntity preference = userNotificationPreferenceRepository.findByUserId(userId)
                 .orElseGet(() -> {
@@ -120,10 +123,12 @@ public class NotificationEventService implements NotificationEventHandlerPort {
         // 3) 변경사항만 반영
         boolean changed = false;
         if (enableAlarms != null && !enableAlarms.equals(preference.getEnableAlarms())) {
+            log.debug("Updating enableAlarms: {} -> {}", preference.getEnableAlarms(), enableAlarms);
             preference.setEnableAlarms(enableAlarms);
             changed = true;
         }
         if (alarmTime != null && !alarmTime.equals(preference.getAlarmTime())) {
+            log.debug("Updating alarmTime: {} -> {}", preference.getAlarmTime(), alarmTime);
             preference.setAlarmTime(alarmTime);
             changed = true;
         }
@@ -136,12 +141,15 @@ public class NotificationEventService implements NotificationEventHandlerPort {
         // 4) 저장 + 예외 분류
         try {
             userNotificationPreferenceRepository.save(preference);
-            log.info("User notification preferences updated event handled: userId={}, enableAlarms={}, alarmTime={}", userId, enableAlarms, alarmTime);
+            log.info("User notification preferences updated: userId={}, enableAlarms={}, alarmTime={}",
+                    userId, preference.getEnableAlarms(), preference.getAlarmTime());
         } catch (DataIntegrityViolationException e) {
+            log.error("Preference violates constraints: userId={}", userId, e);
             //스키마/제약 위반
             throw new IllegalArgumentException("Preference violates constraints", e);
         } catch (TransientDataAccessException e) {
             // 연결/타임아웃/락 등 일시장애 -> 재시도 대상
+            log.error("Transient DB error while updating preference: userId={}", userId, e);
             throw e;
         }    }
 }

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/AsyncConfig.java
@@ -19,7 +19,12 @@ public class AsyncConfig {
         executor.setMaxPoolSize(50);         // 최대 스레드
         executor.setQueueCapacity(10_000);  // 실행 대기 중인 큐 용량
         executor.setThreadNamePrefix("notification-async-"); // 디버깅 로그
+
+        // 요청 스레드의 MDC (traceId)를 비동기 스레드로 전파
+        executor.setTaskDecorator(new MdcTaskDecorator());
+
         executor.initialize();
         return executor;
     }
 }
+

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/config/MdcTaskDecorator.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/config/MdcTaskDecorator.java
@@ -1,0 +1,31 @@
+package com.voiceprint.notification.global.config;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+public class MdcTaskDecorator implements TaskDecorator {
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        // 현재 스레드의 MDC 컨텍스트 복사 (traceId 포함)
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+
+        return () -> {
+            // 실핸 전, 이전 값을 백업해두었다가
+            Map<String, String> previous = MDC.getCopyOfContextMap();
+
+            try {
+                if (contextMap != null) {
+                    MDC.setContextMap(contextMap);
+                } else {
+                    // 부모에 MDC가 없을 경우, 자식에서도 [traceId =] 이게 맞다.
+                    MDC.clear();
+                }
+            } finally {
+                // Runnable 단위의 clear()
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/filter/MdcFilter.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/filter/MdcFilter.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class MdcFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID = "traceId";
+    private static final String TRACE_HEADER = "X-Trace-Id";
 
     /**
      * 실제 필터 로직.
@@ -29,12 +30,23 @@ public class MdcFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String traceId = MDC.get(TRACE_ID);
-            if (traceId == null) {
-                // UUID에서 앞 8자리 사용. - 만약 header를 통해 traceId가 들어온다면 해당 친구 사용.
-                traceId = UUID.randomUUID().toString().substring(0,8);
-                MDC.put(TRACE_ID, traceId);
+            // 1) 먼저 헤더에서 traceId를 찾는다 (서비스 간 전파용)
+            String traceId = request.getHeader(TRACE_HEADER);
+
+            // 2) 헤더에 없으면 MDC에서 한 번 더 확인 (이미 세팅된 경우)
+            if (traceId == null || traceId.isBlank()) {
+                traceId = MDC.get(TRACE_ID);
             }
+
+            // 3) 그래도 없으면 새로 생성 (이 서비스가 최초 진입점일 수도 있으니까)
+            if (traceId == null || traceId.isBlank()) {
+                traceId = UUID.randomUUID().toString().substring(0, 8);
+            }
+            // 4) put.
+            MDC.put(TRACE_ID, traceId);
+
+            // 응답 헤더에도 넣어줌.
+            response.setHeader(TRACE_HEADER, traceId);
 
             filterChain.doFilter(request, response);
         } finally {

--- a/services/notification-service/src/main/java/com/voiceprint/notification/global/filter/MdcFilter.java
+++ b/services/notification-service/src/main/java/com/voiceprint/notification/global/filter/MdcFilter.java
@@ -1,0 +1,47 @@
+package com.voiceprint.notification.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * HTTP 요청마다 traceId를 생성해서 MDC에 넣어주는 필터.
+ * - OncePerRequestFilter 를 상속했기 때문에 한 요청당 한 번만 실행됨.
+ * - 이후 모든 로그에서 %X{traceId} 로 같은 traceId를 확인할 수 있다.
+ */
+@Component
+public class MdcFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+
+    /**
+     * 실제 필터 로직.
+     * 요청이 들어올 때 traceId를 MDC에 넣고,
+     * 체인 이후 finally 에서 MDC를 정리(cleanup) 해준다.
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String traceId = MDC.get(TRACE_ID);
+            if (traceId == null) {
+                // UUID에서 앞 8자리 사용. - 만약 header를 통해 traceId가 들어온다면 해당 친구 사용.
+                traceId = UUID.randomUUID().toString().substring(0,8);
+                MDC.put(TRACE_ID, traceId);
+            }
+
+            filterChain.doFilter(request, response);
+        } finally {
+            // 요청 처리가 끝나면 MDC를 반드시 비워줘야 함.
+            // MDC는 내부적으로 ThreadLocal을 사용하기 때문에,
+            // 스레드풀 환경에서는 이전 요청의 값이 다음 요청에 섞이지 않도록 정리 필수.
+            MDC.clear();
+        }
+    }
+}

--- a/services/notification-service/src/main/resources/logback-spring.xml
+++ b/services/notification-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{traceId:-}] %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
# � feat: Distributed Tracing & MDC Logging System

## 💡 개요
마이크로서비스 환경에서 요청의 흐름을 추적하기 어려웠던 문제를 해결하기 위해 **분산 트레이싱(Distributed Tracing)** 환경을 구축했습니다.
API Gateway에서 생성한 `X-Trace-Id`를 각 마이크로서비스와 Kafka 메시지 큐, 그리고 비동기 스레드까지 전파하여
로그만으로도 전체 시스템 내에서의 요청 흐름을 파악할 수 있도록 개선했습니다.

---

## 🔧 주요 변경사항

### 🚪 1. Gateway 계층 트레이싱 적용
- **Trace ID 생성 및 전파**: `GlobalLoggerFilter`에서 요청별 고유 ID(`X-Trace-Id`)를 생성하여 Downstream 서비스로 전달.
- **Logback 설정**: Gateway 로그에도 해당 ID가 남도록 설정 추가.

### 📨 2. Kafka 메시징 트레이싱 연동 (Notification Service)
- **MDC <-> Kafka Header 매핑**: 
    - Producer: 이벤트 발행 시 MDC의 `traceId`를 Kafka 헤더에 포함.
    - Consumer: 메시지 수신 시 헤더의 `traceId`를 다시 MDC 컨텍스트에 복원 (`NotificationConsumer`).
- **결과**: HTTP 요청으로 시작되어 Kafka 이벤트로 이어지는 비동기 흐름 끊김 없이 추적 가능.

### 🧵 3. 비동기 스레드 컨텍스트 전파
- **Async TaskDecorator 구현**: `@Async` 실행 시 메인 스레드의 MDC 컨텍스트를 작업 스레드로 복사하는 `MdcTaskDecorator` 추가.
- **스레드 풀 설정**: `AsyncConfig`에 Decorator 적용 완료.

### �️ 4. 멱등성 및 안정성 강화
- **중복 소비 방지**: `NotificationConsumer`에 `eventId` 기반의 멱등성 검사 로직 추가.
- **공통 필터**: Core 모듈에 `MdcFilter`를 추가하여 전사적 표준화.

---

## 🧩 아키텍처 흐름 (Trace Propagation)

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant Service(MVC)
    participant Kafka
    participant Consumer(Async)

    Client->>Gateway: API Request
    Gateway->>Gateway: Gen X-Trace-Id (MDC)
    Gateway->>Service(MVC): Header: X-Trace-Id
    Service(MVC)->>Service(MVC): MDC.put(traceId)
    Service(MVC)->>Kafka: Publish (Header: traceId)
    Kafka->>Consumer(Async): Consume
    Consumer(Async)->>Consumer(Async): MDC.put(Header.traceId)
    Note right of Consumer(Async): 로그에 동일한 TraceId 기록됨
```
